### PR TITLE
feat: replay captured requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ ProxyBoy is a man-in-the-middle (MITM) HTTP/HTTPS proxy that captures, inspects,
 - **System Proxy Integration** — Toggle Windows system proxy on/off from the app
 - **HAR Export/Import** — Standard HAR format for sharing captures with other tools
 - **Configurable Columns** — Show/hide columns, sort by any field, timestamps
+- **Replay Requests** — Repeat captured requests from the traffic list to reproduce problems quickly
 - **Copy as cURL** — Right-click any request to copy it as a cURL command
 - **Dark Theme** — Tokyo Night-inspired dark UI
 - **Detachable AI Panel** — Pop the assistant out into its own window

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -4,6 +4,7 @@ import { IPC_CHANNELS } from '../../shared/constants';
 import { ProxyEngine } from '../proxy/engine';
 import { CertificateManager } from '../proxy/certificate';
 import { AgentClient } from '../agent/client';
+import { replayFlowThroughProxy } from '../proxy/replay';
 import { setSystemProxy, clearSystemProxy, isSystemProxyEnabled } from '../utils/windows-proxy';
 import { ProxyState, Rule, HttpFlow } from '../../shared/types';
 import { flowsToHar } from '../utils/har';
@@ -122,6 +123,24 @@ export function registerIpcHandlers(
     try {
       proxyEngine.clearFlows();
       clearAllFlows();
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.TRAFFIC_REPEAT, async (_event, id: string) => {
+    try {
+      if (!proxyEngine.isRunning()) {
+        return { success: false, error: 'Start the proxy before replaying a request.' };
+      }
+
+      const flow = proxyEngine.getFlow(id);
+      if (!flow) {
+        return { success: false, error: 'That request is no longer available to replay.' };
+      }
+
+      await replayFlowThroughProxy(flow, proxyEngine.getPort());
       return { success: true };
     } catch (error: any) {
       return { success: false, error: error.message };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -20,6 +20,7 @@ const api = {
     getFlow: (id: string): Promise<HttpFlow | null> =>
       ipcRenderer.invoke(IPC_CHANNELS.TRAFFIC_GET_FLOW, id),
     clear: () => ipcRenderer.invoke(IPC_CHANNELS.TRAFFIC_CLEAR),
+    repeat: (id: string) => ipcRenderer.invoke(IPC_CHANNELS.TRAFFIC_REPEAT, id),
     onNewFlow: (callback: (flow: HttpFlow) => void) => {
       const handler = (_event: any, flow: HttpFlow) => callback(flow);
       ipcRenderer.on(IPC_CHANNELS.TRAFFIC_NEW_FLOW, handler);

--- a/src/main/proxy/engine.ts
+++ b/src/main/proxy/engine.ts
@@ -4,6 +4,7 @@ import type { IProxy } from 'http-mitm-proxy';
 import { randomUUID } from 'crypto';
 import { gunzipSync, inflateSync, brotliDecompressSync } from 'zlib';
 import { HttpFlow, HttpRequest, HttpResponse } from '../../shared/types';
+import { INTERNAL_REPLAY_HEADER } from '../../shared/constants';
 import { CertificateManager } from './certificate';
 import { Interceptor } from './interceptor';
 import { DnsResolverService } from './dns-resolver';
@@ -189,6 +190,11 @@ export class ProxyEngine extends EventEmitter {
       const flowId = randomUUID();
       const chunks: Buffer[] = [];
       const startTime = Date.now();
+      const replayed = Boolean(ctx.clientToProxyRequest.headers[INTERNAL_REPLAY_HEADER]);
+      if (replayed) {
+        delete ctx.clientToProxyRequest.headers[INTERNAL_REPLAY_HEADER];
+      }
+      const initialTags = replayed ? ['replayed'] : [];
 
       const request: HttpRequest = {
         id: randomUUID(),
@@ -225,7 +231,7 @@ export class ProxyEngine extends EventEmitter {
               duration: Date.now() - startTime,
             },
             state: 'complete',
-            tags: ['map-local'],
+            tags: [...initialTags, 'map-local'],
             createdAt: startTime,
           };
           this.flows.set(flowId, flow);
@@ -238,7 +244,7 @@ export class ProxyEngine extends EventEmitter {
         id: flowId,
         request,
         state: 'pending',
-        tags: [],
+        tags: [...initialTags],
         createdAt: startTime,
         timing: { start: startTime },
       };

--- a/src/main/proxy/replay.test.ts
+++ b/src/main/proxy/replay.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { buildRawHttpRequest, buildReplayHeaders } from './replay';
+
+describe('replay helpers', () => {
+  it('drops hop-by-hop headers and injects replay metadata', () => {
+    const headers = buildReplayHeaders(
+      {
+        host: 'example.com',
+        connection: 'keep-alive',
+        'proxy-connection': 'keep-alive',
+        accept: 'application/json',
+      },
+      new URL('https://api.example.com/users?page=2'),
+      true,
+      12,
+    );
+
+    expect(headers).toEqual({
+      accept: 'application/json',
+      Host: 'api.example.com',
+      Connection: 'close',
+      'x-proxyboy-replay': '1',
+      'Content-Length': '12',
+    });
+  });
+
+  it('builds a raw HTTP request payload with the target path and body', () => {
+    const payload = buildRawHttpRequest(
+      'POST',
+      new URL('https://api.example.com/users?page=2'),
+      {
+        Host: 'api.example.com',
+        Connection: 'close',
+      },
+      Buffer.from('hello'),
+    ).toString('utf8');
+
+    expect(payload).toContain('POST /users?page=2 HTTP/1.1\r\n');
+    expect(payload).toContain('Host: api.example.com\r\n');
+    expect(payload).toContain('\r\n\r\nhello');
+  });
+});

--- a/src/main/proxy/replay.ts
+++ b/src/main/proxy/replay.ts
@@ -1,0 +1,243 @@
+import * as http from 'http';
+import * as tls from 'tls';
+import { URL } from 'url';
+import type { HttpFlow, HttpHeaders } from '../../shared/types';
+import { INTERNAL_REPLAY_HEADER } from '../../shared/constants';
+
+const REPLAY_TIMEOUT_MS = 30000;
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'expect',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'proxy-connection',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+function headerValue(value: string | string[]): string {
+  return Array.isArray(value) ? value.join(', ') : value;
+}
+
+function getRequestBody(body: HttpFlow['request']['body']): { buffer?: Buffer; hasBody: boolean } {
+  if (typeof body === 'string') {
+    return { buffer: Buffer.from(body), hasBody: true };
+  }
+
+  if (Buffer.isBuffer(body)) {
+    return { buffer: body, hasBody: true };
+  }
+
+  return { hasBody: false };
+}
+
+export function buildReplayHeaders(
+  headers: HttpHeaders,
+  target: URL,
+  hasBody: boolean,
+  bodyLength: number,
+): Record<string, string> {
+  const replayHeaders: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(headers)) {
+    const lowerName = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lowerName) || lowerName === 'host') {
+      continue;
+    }
+
+    replayHeaders[name] = headerValue(value);
+  }
+
+  replayHeaders.Host = target.host;
+  replayHeaders.Connection = 'close';
+  replayHeaders[INTERNAL_REPLAY_HEADER] = '1';
+
+  if (hasBody) {
+    replayHeaders['Content-Length'] = String(bodyLength);
+  }
+
+  return replayHeaders;
+}
+
+export function buildRawHttpRequest(
+  method: string,
+  target: URL,
+  headers: Record<string, string>,
+  body?: Buffer,
+): Buffer {
+  const path = `${target.pathname || '/'}${target.search}`;
+  const lines = [`${method} ${path} HTTP/1.1`];
+
+  for (const [name, value] of Object.entries(headers)) {
+    lines.push(`${name}: ${value}`);
+  }
+
+  const head = Buffer.from(`${lines.join('\r\n')}\r\n\r\n`, 'utf8');
+  if (!body || body.length === 0) {
+    return head;
+  }
+
+  return Buffer.concat([head, body]);
+}
+
+function replayHttp(
+  flow: HttpFlow,
+  proxyPort: number,
+  target: URL,
+  headers: Record<string, string>,
+  body?: Buffer,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      req.destroy(new Error('Replay request timed out.'));
+    }, REPLAY_TIMEOUT_MS);
+
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      req.removeListener('error', handleError);
+      callback();
+    };
+
+    const handleError = (error: Error) => {
+      settle(() => reject(error));
+    };
+
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port: proxyPort,
+        method: flow.request.method,
+        path: target.toString(),
+        headers,
+      },
+      (res) => {
+        res.resume();
+        res.once('end', () => settle(resolve));
+      },
+    );
+
+    req.once('error', handleError);
+
+    if (body && body.length > 0) {
+      req.write(body);
+    }
+
+    req.end();
+  });
+}
+
+function replayHttps(
+  flow: HttpFlow,
+  proxyPort: number,
+  target: URL,
+  headers: Record<string, string>,
+  body?: Buffer,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let tlsSocket: tls.TLSSocket | null = null;
+
+    const handleTlsData = () => {
+      // Drain the replayed response so the proxy can complete the captured flow.
+    };
+    const handleTlsEnd = () => {
+      settle(resolve);
+    };
+    const handleTlsClose = (hadError: boolean) => {
+      if (!hadError) {
+        settle(resolve);
+      }
+    };
+    const handleTlsError = (error: Error) => {
+      settle(() => reject(error));
+    };
+    const handleConnectError = (error: Error) => {
+      settle(() => reject(error));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      connectReq.removeListener('error', handleConnectError);
+      if (!tlsSocket) return;
+      tlsSocket.removeListener('data', handleTlsData);
+      tlsSocket.removeListener('end', handleTlsEnd);
+      tlsSocket.removeListener('close', handleTlsClose);
+      tlsSocket.removeListener('error', handleTlsError);
+    };
+
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const timeout = setTimeout(() => {
+      if (tlsSocket) {
+        tlsSocket.destroy(new Error('Replay request timed out.'));
+        return;
+      }
+      connectReq.destroy(new Error('Replay tunnel timed out.'));
+    }, REPLAY_TIMEOUT_MS);
+
+    const connectReq = http.request({
+      host: '127.0.0.1',
+      port: proxyPort,
+      method: 'CONNECT',
+      path: `${target.hostname}:${target.port || '443'}`,
+    });
+
+    connectReq.once('error', handleConnectError);
+
+    connectReq.once('connect', (res, socket) => {
+      connectReq.removeListener('error', handleConnectError);
+      if (res.statusCode !== 200) {
+        socket.destroy();
+        settle(() => reject(new Error(`Replay tunnel failed with status ${res.statusCode}.`)));
+        return;
+      }
+
+      tlsSocket = tls.connect(
+        {
+          socket,
+          servername: target.hostname,
+        },
+        () => {
+          tlsSocket?.end(buildRawHttpRequest(flow.request.method, target, headers, body));
+        },
+      );
+
+      tlsSocket.once('error', handleTlsError);
+      tlsSocket.on('data', handleTlsData);
+      tlsSocket.once('end', handleTlsEnd);
+      tlsSocket.once('close', handleTlsClose);
+    });
+
+    connectReq.end();
+  });
+}
+
+export async function replayFlowThroughProxy(flow: HttpFlow, proxyPort: number): Promise<void> {
+  const target = new URL(flow.request.url);
+  const { buffer: body, hasBody } = getRequestBody(flow.request.body);
+  const headers = buildReplayHeaders(flow.request.headers, target, hasBody, body?.length ?? 0);
+
+  if (target.protocol === 'https:') {
+    await replayHttps(flow, proxyPort, target, headers, body);
+    return;
+  }
+
+  if (target.protocol === 'http:') {
+    await replayHttp(flow, proxyPort, target, headers, body);
+    return;
+  }
+
+  throw new Error(`Unsupported replay protocol: ${target.protocol}`);
+}

--- a/src/renderer/components/traffic/TrafficList.tsx
+++ b/src/renderer/components/traffic/TrafficList.tsx
@@ -166,6 +166,16 @@ export default function TrafficList({ flows, selectedId, onSelect }: Props) {
   const buildMenuItems = useCallback((flow: HttpFlow): ContextMenuItem[] => {
     return [
       {
+        label: 'Repeat Request',
+        icon: '↻',
+        onClick: async () => {
+          const result = await window.proxyboy?.traffic.repeat(flow.id);
+          if (!result?.success) {
+            window.alert(result?.error || 'Failed to replay the request.');
+          }
+        },
+      },
+      {
         label: 'Copy as cURL',
         icon: '⌘',
         onClick: () => navigator.clipboard.writeText(flowToCurl(flow)),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -15,6 +15,7 @@ export const IPC_CHANNELS = {
   TRAFFIC_CLEAR: 'traffic:clear',
   TRAFFIC_GET_FLOWS: 'traffic:get-flows',
   TRAFFIC_GET_FLOW: 'traffic:get-flow',
+  TRAFFIC_REPEAT: 'traffic:repeat',
   
   // Rules
   RULES_GET_ALL: 'rules:get-all',
@@ -57,3 +58,4 @@ export const DEFAULT_PROXY_PORT = 9090;
 export const DEFAULT_PROXY_HOST = '127.0.0.1';
 export const APP_NAME = 'ProxyBoy';
 export const APP_VERSION = '1.0.0';
+export const INTERNAL_REPLAY_HEADER = 'x-proxyboy-replay';


### PR DESCRIPTION
## Summary
- add a right-click **Repeat Request** action in the traffic list
- replay requests through the local proxy so they are captured like normal traffic
- tag replayed flows and cover the replay request builder with tests

## Validation
- npm run lint
- npm test
- npm run build

Closes #4