### PR TITLE
feat: add cookie inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ ProxyBoy is a man-in-the-middle (MITM) HTTP/HTTPS proxy that captures, inspects,
 
 - **Traffic Capture** — Intercept HTTP and HTTPS traffic with automatic SSL certificate generation
 - **Request/Response Inspector** — View headers, bodies (JSON, HTML, XML, images), timing, and metadata
+- **Cookie Inspector** — Parse request cookies and `Set-Cookie` headers into a structured, searchable view
 - **AI Assistant** — Chat panel powered by GitHub Copilot that can search traffic, analyze patterns, create rules, and export data
 - **Breakpoint Rules** — Pause requests/responses mid-flight, inspect them, then forward or drop
 - **Map Local Rules** — Serve local files instead of remote responses for mocking APIs

--- a/src/renderer/components/traffic/CookieView.tsx
+++ b/src/renderer/components/traffic/CookieView.tsx
@@ -1,0 +1,182 @@
+import React, { useMemo, useState } from 'react';
+import type { HttpFlow } from '../../../shared/types';
+import {
+  parseRequestCookies,
+  parseResponseCookies,
+  type ParsedRequestCookie,
+  type ParsedResponseCookie,
+} from '../../utils/cookies';
+
+interface Props {
+  flow: HttpFlow;
+}
+
+function matchesSearch(value: string | undefined, query: string): boolean {
+  return value?.toLowerCase().includes(query) ?? false;
+}
+
+function matchesRequestCookie(cookie: ParsedRequestCookie, query: string): boolean {
+  return (
+    matchesSearch(cookie.name, query) ||
+    matchesSearch(cookie.value, query) ||
+    matchesSearch(cookie.raw, query)
+  );
+}
+
+function matchesResponseCookie(cookie: ParsedResponseCookie, query: string): boolean {
+  return (
+    matchesSearch(cookie.name, query) ||
+    matchesSearch(cookie.value, query) ||
+    matchesSearch(cookie.domain, query) ||
+    matchesSearch(cookie.path, query) ||
+    matchesSearch(cookie.expires, query) ||
+    matchesSearch(cookie.maxAge, query) ||
+    matchesSearch(cookie.sameSite, query) ||
+    matchesSearch(cookie.raw, query)
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-pb-border px-3 py-5 text-xs text-pb-text-dim">
+      {message}
+    </div>
+  );
+}
+
+export default function CookieView({ flow }: Props) {
+  const [searchText, setSearchText] = useState('');
+
+  const requestCookies = useMemo(
+    () => parseRequestCookies(flow.request.headers).sort((a, b) => a.name.localeCompare(b.name)),
+    [flow.request.headers],
+  );
+  const responseCookies = useMemo(
+    () => parseResponseCookies(flow.response?.headers || {}).sort((a, b) => a.name.localeCompare(b.name)),
+    [flow.response?.headers],
+  );
+
+  const query = searchText.trim().toLowerCase();
+  const filteredRequestCookies = useMemo(
+    () => (query ? requestCookies.filter((cookie) => matchesRequestCookie(cookie, query)) : requestCookies),
+    [query, requestCookies],
+  );
+  const filteredResponseCookies = useMemo(
+    () => (query ? responseCookies.filter((cookie) => matchesResponseCookie(cookie, query)) : responseCookies),
+    [query, responseCookies],
+  );
+
+  const totalCookieCount = requestCookies.length + responseCookies.length;
+  const visibleCookieCount = filteredRequestCookies.length + filteredResponseCookies.length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1 max-w-sm">
+          <input
+            type="text"
+            value={searchText}
+            onChange={(event) => setSearchText(event.target.value)}
+            placeholder="Filter cookies by name, value, domain, or path"
+            className="w-full h-8 bg-pb-surface border border-pb-border rounded px-3 pr-8 text-xs text-pb-text placeholder-pb-text-dim focus:outline-none focus:border-pb-accent"
+          />
+          {searchText && (
+            <button
+              onClick={() => setSearchText('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-pb-text-dim hover:text-pb-text text-xs"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+        <div className="text-xs text-pb-text-dim">
+          {visibleCookieCount} of {totalCookieCount} cookies
+        </div>
+      </div>
+
+      <section className="space-y-2">
+        <div>
+          <h3 className="text-xs font-semibold text-pb-text-dim uppercase">Request Cookies</h3>
+          <p className="text-[11px] text-pb-text-dim mt-1">
+            Parsed from the outgoing <span className="font-mono text-pb-text">Cookie</span> header.
+          </p>
+        </div>
+
+        {requestCookies.length === 0 ? (
+          <EmptyState message="This request did not send any cookies." />
+        ) : filteredRequestCookies.length === 0 ? (
+          <EmptyState message="No request cookies match the current filter." />
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-pb-border bg-pb-surface">
+            <table className="min-w-full text-xs">
+              <thead className="bg-pb-bg/70 text-pb-text-dim">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">Name</th>
+                  <th className="px-3 py-2 text-left font-medium">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredRequestCookies.map((cookie) => (
+                  <tr key={`request-${cookie.name}-${cookie.raw}`} className="border-t border-pb-border">
+                    <td className="px-3 py-2 font-mono text-pb-accent whitespace-nowrap">{cookie.name}</td>
+                    <td className="px-3 py-2 font-mono text-pb-text break-all">{cookie.value || '(empty)'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <div>
+          <h3 className="text-xs font-semibold text-pb-text-dim uppercase">Response Cookies</h3>
+          <p className="text-[11px] text-pb-text-dim mt-1">
+            Parsed from the incoming <span className="font-mono text-pb-text">Set-Cookie</span> headers.
+          </p>
+        </div>
+
+        {responseCookies.length === 0 ? (
+          <EmptyState message="This response did not set any cookies." />
+        ) : filteredResponseCookies.length === 0 ? (
+          <EmptyState message="No response cookies match the current filter." />
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-pb-border bg-pb-surface">
+            <table className="min-w-full text-xs">
+              <thead className="bg-pb-bg/70 text-pb-text-dim">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">Name</th>
+                  <th className="px-3 py-2 text-left font-medium">Value</th>
+                  <th className="px-3 py-2 text-left font-medium">Domain</th>
+                  <th className="px-3 py-2 text-left font-medium">Path</th>
+                  <th className="px-3 py-2 text-left font-medium">Expires / Max-Age</th>
+                  <th className="px-3 py-2 text-left font-medium">Flags</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredResponseCookies.map((cookie) => (
+                  <tr key={`response-${cookie.name}-${cookie.raw}`} className="border-t border-pb-border">
+                    <td className="px-3 py-2 font-mono text-pb-accent whitespace-nowrap">{cookie.name}</td>
+                    <td className="px-3 py-2 font-mono text-pb-text break-all">{cookie.value || '(empty)'}</td>
+                    <td className="px-3 py-2 text-pb-text break-all">{cookie.domain || '—'}</td>
+                    <td className="px-3 py-2 text-pb-text break-all">{cookie.path || '—'}</td>
+                    <td className="px-3 py-2 text-pb-text break-all">
+                      {cookie.expires || cookie.maxAge
+                        ? [cookie.expires, cookie.maxAge ? `Max-Age=${cookie.maxAge}` : null].filter(Boolean).join(' • ')
+                        : '—'}
+                    </td>
+                    <td className="px-3 py-2 text-pb-text break-all">
+                      {[cookie.sameSite ? `SameSite=${cookie.sameSite}` : null, cookie.secure ? 'Secure' : null, cookie.httpOnly ? 'HttpOnly' : null]
+                        .filter(Boolean)
+                        .join(' • ') || '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/renderer/components/traffic/TrafficDetail.tsx
+++ b/src/renderer/components/traffic/TrafficDetail.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import RequestView from './RequestView';
 import ResponseView from './ResponseView';
+import CookieView from './CookieView';
 import type { HttpFlow } from '../../../shared/types';
 
 interface Props {
@@ -8,23 +9,36 @@ interface Props {
   onClose: () => void;
 }
 
-type Tab = 'request' | 'response' | 'preview' | 'timing';
+type Tab = 'request' | 'response' | 'cookies' | 'preview' | 'timing';
 
 function isImageFlow(flow: HttpFlow): boolean {
   const ct = flow.response?.headers?.['content-type'];
   return ct ? String(ct).toLowerCase().startsWith('image/') : false;
 }
 
+function hasHeaderValue(value?: string | string[]): boolean {
+  if (!value) return false;
+  return Array.isArray(value) ? value.some((entry) => entry.trim().length > 0) : value.trim().length > 0;
+}
+
 export default function TrafficDetail({ flow, onClose }: Props) {
   const hasPreview = isImageFlow(flow);
+  const hasCookies = hasHeaderValue(flow.request.headers.cookie) || hasHeaderValue(flow.response?.headers['set-cookie']);
   const [tab, setTab] = useState<Tab>(hasPreview ? 'preview' : 'request');
 
   const tabs: { id: Tab; label: string; show: boolean }[] = [
     { id: 'request', label: 'Request', show: true },
     { id: 'response', label: 'Response', show: true },
+    { id: 'cookies', label: 'Cookies', show: hasCookies },
     { id: 'preview', label: '🖼 Preview', show: hasPreview },
     { id: 'timing', label: 'Timing', show: true },
   ];
+
+  useEffect(() => {
+    if ((tab === 'cookies' && !hasCookies) || (tab === 'preview' && !hasPreview)) {
+      setTab(hasPreview ? 'preview' : 'request');
+    }
+  }, [hasCookies, hasPreview, tab]);
 
   const imageDataUrl = useMemo(() => {
     if (!hasPreview || !flow.response?.body) return null;
@@ -78,6 +92,7 @@ export default function TrafficDetail({ flow, onClose }: Props) {
         {tab === 'response' && !flow.response && (
           <div className="text-pb-text-dim text-sm">Waiting for response...</div>
         )}
+        {tab === 'cookies' && <CookieView flow={flow} />}
         {tab === 'preview' && imageDataUrl && (
           <div className="flex flex-col items-center gap-4">
             <div

--- a/src/renderer/utils/cookies.test.ts
+++ b/src/renderer/utils/cookies.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { parseRequestCookies, parseResponseCookies } from './cookies';
+
+describe('parseRequestCookies', () => {
+  it('parses standard cookie headers into name/value pairs', () => {
+    expect(parseRequestCookies({
+      cookie: 'session=abc123; theme=dark; token=hello=world',
+    })).toEqual([
+      { name: 'session', value: 'abc123', raw: 'session=abc123' },
+      { name: 'theme', value: 'dark', raw: 'theme=dark' },
+      { name: 'token', value: 'hello=world', raw: 'token=hello=world' },
+    ]);
+  });
+});
+
+describe('parseResponseCookies', () => {
+  it('parses structured Set-Cookie attributes', () => {
+    expect(parseResponseCookies({
+      'set-cookie': [
+        'session=abc123; Path=/; HttpOnly; Secure; SameSite=Lax',
+        'theme=dark; Domain=example.com; Expires=Wed, 21 Oct 2026 07:28:00 GMT; Max-Age=3600',
+      ],
+    })).toEqual([
+      {
+        name: 'session',
+        value: 'abc123',
+        path: '/',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'Lax',
+        raw: 'session=abc123; Path=/; HttpOnly; Secure; SameSite=Lax',
+      },
+      {
+        name: 'theme',
+        value: 'dark',
+        domain: 'example.com',
+        expires: 'Wed, 21 Oct 2026 07:28:00 GMT',
+        maxAge: '3600',
+        secure: false,
+        httpOnly: false,
+        raw: 'theme=dark; Domain=example.com; Expires=Wed, 21 Oct 2026 07:28:00 GMT; Max-Age=3600',
+      },
+    ]);
+  });
+});

--- a/src/renderer/utils/cookies.ts
+++ b/src/renderer/utils/cookies.ts
@@ -1,0 +1,115 @@
+import type { HttpHeaders } from '../../shared/types';
+
+export interface ParsedRequestCookie {
+  name: string;
+  value: string;
+  raw: string;
+}
+
+export interface ParsedResponseCookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  expires?: string;
+  maxAge?: string;
+  sameSite?: string;
+  secure: boolean;
+  httpOnly: boolean;
+  raw: string;
+}
+
+function getHeaderValues(value?: string | string[]): string[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function splitCookiePair(value: string): { name: string; value: string } | null {
+  const separatorIndex = value.indexOf('=');
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const name = value.slice(0, separatorIndex).trim();
+  const cookieValue = value.slice(separatorIndex + 1).trim();
+  if (!name) {
+    return null;
+  }
+
+  return { name, value: cookieValue };
+}
+
+export function parseRequestCookies(headers: HttpHeaders): ParsedRequestCookie[] {
+  const cookieHeaders = getHeaderValues(headers.cookie);
+  const parsedCookies: ParsedRequestCookie[] = [];
+
+  for (const header of cookieHeaders) {
+    for (const part of header.split(';')) {
+      const raw = part.trim();
+      if (!raw) continue;
+
+      const pair = splitCookiePair(raw);
+      if (!pair) continue;
+      parsedCookies.push({ ...pair, raw });
+    }
+  }
+
+  return parsedCookies;
+}
+
+export function parseResponseCookies(headers: HttpHeaders): ParsedResponseCookie[] {
+  return getHeaderValues(headers['set-cookie'])
+    .map((header) => {
+      const parts = header.split(';').map((part) => part.trim()).filter(Boolean);
+      if (parts.length === 0) {
+        return null;
+      }
+
+      const cookiePair = splitCookiePair(parts[0]);
+      if (!cookiePair) {
+        return null;
+      }
+
+      const cookie: ParsedResponseCookie = {
+        ...cookiePair,
+        secure: false,
+        httpOnly: false,
+        raw: header,
+      };
+
+      for (const attributePart of parts.slice(1)) {
+        const [attributeName, ...attributeValueParts] = attributePart.split('=');
+        const lowerAttributeName = attributeName.toLowerCase();
+        const attributeValue = attributeValueParts.join('=').trim();
+
+        switch (lowerAttributeName) {
+          case 'domain':
+            cookie.domain = attributeValue || undefined;
+            break;
+          case 'path':
+            cookie.path = attributeValue || undefined;
+            break;
+          case 'expires':
+            cookie.expires = attributeValue || undefined;
+            break;
+          case 'max-age':
+            cookie.maxAge = attributeValue || undefined;
+            break;
+          case 'samesite':
+            cookie.sameSite = attributeValue || undefined;
+            break;
+          case 'secure':
+            cookie.secure = true;
+            break;
+          case 'httponly':
+            cookie.httpOnly = true;
+            break;
+          default:
+            break;
+        }
+      }
+
+      return cookie;
+    })
+    .filter((cookie): cookie is ParsedResponseCookie => cookie !== null);
+}


### PR DESCRIPTION
## Summary
- add a dedicated Cookies tab in traffic details for parsed request and response cookies
- parse Cookie and Set-Cookie headers into a searchable structured view
- keep detail tabs in sync when switching between flows with different available tabs

## Testing
- npm run lint
- npm test
- npm run build

Closes #18