### PR TITLE
feat: add GraphQL filtering to agent traffic search

### DIFF
--- a/src/main/agent/client.test.ts
+++ b/src/main/agent/client.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { HttpFlow } from '../../shared/types';
+import { matchesSearchTraffic } from './client';
+
+interface FlowOverrides extends Omit<Partial<HttpFlow>, 'request' | 'response'> {
+  request?: Partial<HttpFlow['request']>;
+  response?: Partial<NonNullable<HttpFlow['response']>>;
+}
+
+function createFlow(overrides?: FlowOverrides): HttpFlow {
+  const { request: requestOverrides, response: responseOverrides, ...flowOverrides } = overrides || {};
+
+  return {
+    id: 'flow-1',
+    request: {
+      id: 'req-1',
+      method: 'POST',
+      url: 'https://api.example.com/graphql',
+      protocol: 'https',
+      host: 'api.example.com',
+      path: '/graphql',
+      headers: { 'content-type': 'application/json' },
+      bodySize: 0,
+      timestamp: Date.now(),
+      graphqlOperationName: 'GetViewer',
+      graphqlOperationType: 'query',
+      ...(requestOverrides || {}),
+    },
+    response: {
+      id: 'res-1',
+      requestId: 'req-1',
+      statusCode: 200,
+      statusMessage: 'OK',
+      headers: { 'content-type': 'application/json' },
+      bodySize: 0,
+      timestamp: Date.now(),
+      duration: 120,
+      ...(responseOverrides || {}),
+    },
+    state: 'complete',
+    tags: ['graphql'],
+    createdAt: Date.now(),
+    ...flowOverrides,
+  };
+}
+
+describe('matchesSearchTraffic', () => {
+  it('matches GraphQL operation names case-insensitively', () => {
+    expect(matchesSearchTraffic(createFlow(), { graphqlOperationName: 'viewer' })).toBe(true);
+  });
+
+  it('rejects flows with a different GraphQL operation name', () => {
+    expect(matchesSearchTraffic(createFlow(), { graphqlOperationName: 'listusers' })).toBe(false);
+  });
+
+  it('combines GraphQL filtering with the existing URL and method filters', () => {
+    expect(matchesSearchTraffic(createFlow(), {
+      query: 'graphql',
+      method: 'post',
+      graphqlOperationName: 'getviewer',
+    })).toBe(true);
+  });
+});

--- a/src/main/agent/client.ts
+++ b/src/main/agent/client.ts
@@ -44,6 +44,44 @@ function previewBody(body?: Buffer | string): string | null {
   return body.slice(0, 5000);
 }
 
+export interface SearchTrafficArgs {
+  query?: string;
+  method?: string;
+  statusCode?: number;
+  minDuration?: number;
+  graphqlOperationName?: string;
+}
+
+export function matchesSearchTraffic(flow: HttpFlow, args: SearchTrafficArgs): boolean {
+  if (args.query) {
+    const query = args.query.toLowerCase();
+    if (!flow.request.url.toLowerCase().includes(query)) {
+      return false;
+    }
+  }
+
+  if (args.method && flow.request.method !== args.method.toUpperCase()) {
+    return false;
+  }
+
+  if (args.statusCode && flow.response?.statusCode !== args.statusCode) {
+    return false;
+  }
+
+  if (args.minDuration && (!flow.response || flow.response.duration < args.minDuration)) {
+    return false;
+  }
+
+  if (args.graphqlOperationName) {
+    const graphqlOperationName = flow.request.graphqlOperationName?.toLowerCase() || '';
+    if (!graphqlOperationName.includes(args.graphqlOperationName.toLowerCase())) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export interface RuleManager {
   createRule(rule: Rule): void;
 }
@@ -122,6 +160,8 @@ export class AgentClient {
       id: flow.id,
       method: flow.request.method,
       url: flow.request.url,
+      graphqlOperationName: flow.request.graphqlOperationName || null,
+      graphqlOperationType: flow.request.graphqlOperationType || null,
       status: flow.response?.statusCode || null,
       duration: flow.response?.duration || null,
       bodySize: flow.response?.bodySize || 0,
@@ -142,14 +182,21 @@ export class AgentClient {
         },
       }),
       defineTool('searchTraffic', {
-        description: 'Search captured traffic by query, method, status code, or min duration',
-        parameters: { type: 'object', properties: { query: { type: 'string' }, method: { type: 'string' }, statusCode: { type: 'number' }, minDuration: { type: 'number' } } },
+        description: 'Search captured traffic by query, method, status code, min duration, or GraphQL operation name',
+        parameters: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            method: { type: 'string' },
+            statusCode: { type: 'number' },
+            minDuration: { type: 'number' },
+            graphqlOperationName: { type: 'string' },
+          },
+        },
         handler: async (args: any) => {
+          const filters = (args || {}) as SearchTrafficArgs;
           let flows = engine.getFlows();
-          if (args?.query) { const q = args.query.toLowerCase(); flows = flows.filter((f: HttpFlow) => f.request.url.toLowerCase().includes(q)); }
-          if (args?.method) { flows = flows.filter((f: HttpFlow) => f.request.method === args.method.toUpperCase()); }
-          if (args?.statusCode) { flows = flows.filter((f: HttpFlow) => f.response?.statusCode === args.statusCode); }
-          if (args?.minDuration) { flows = flows.filter((f: HttpFlow) => f.response && f.response.duration >= args.minDuration); }
+          flows = flows.filter((flow: HttpFlow) => matchesSearchTraffic(flow, filters));
           return { count: flows.length, flows: flows.slice(0, 50).map(summarizeFlow) };
         },
       }),

--- a/src/main/agent/prompts.ts
+++ b/src/main/agent/prompts.ts
@@ -14,7 +14,7 @@ When users ask you to:
 - **Analyze traffic**: Use getRecentTraffic or searchTraffic to fetch relevant flows, then provide insights about patterns, errors, performance issues, or anomalies.
 - **Debug errors**: Use getErrorFlows to find failed requests, analyze headers and bodies, and suggest fixes.
 - **Create rules**: Use createBreakpointRule or createMapLocalRule based on the user's intent.
-- **Find specific requests**: Use searchTraffic with appropriate query terms.
+- **Find specific requests**: Use searchTraffic with appropriate query terms, HTTP filters, or GraphQL operation names.
 - **Export data**: Use exportHar to generate HAR files.
 
 ## Response Style


### PR DESCRIPTION
## Summary

- add GraphQL operation name filtering to the `searchTraffic` agent tool
- include GraphQL metadata in the summarized flow results returned to the assistant
- add focused coverage for the new GraphQL search matching helper

## Notes

- Part 2 of #10
- Stacked on top of #30 and intended to merge after it
- I could not rerun local package validation in this shared environment because the project dependencies are currently unavailable to the shell session
