### PR TITLE
feat: add configurable traffic row color accents

### DIFF
--- a/src/renderer/components/settings/SettingsPanel.tsx
+++ b/src/renderer/components/settings/SettingsPanel.tsx
@@ -1,8 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { useAppStore } from '../../stores/app';
+import type { TrafficRowColorMode } from '../../utils/traffic-row-colors';
 
 export default function SettingsPanel() {
-  const { proxyPort, theme, noCacheEnabled, setNoCacheEnabled } = useAppStore();
+  const {
+    proxyPort,
+    theme,
+    noCacheEnabled,
+    trafficRowColorMode,
+    setNoCacheEnabled,
+    setTrafficRowColorMode,
+  } = useAppStore();
   const [autoStart, setAutoStart] = useState(() =>
     localStorage.getItem('proxyboy-auto-start') === 'true'
   );
@@ -197,8 +205,27 @@ export default function SettingsPanel() {
       <Section title="Appearance">
         <Row label="Theme">
           <div className="flex gap-2">
-            <ThemeOption label="Dark" active={theme === 'dark'} />
-            <ThemeOption label="Light" disabled />
+            <OptionButton label="Dark" active={theme === 'dark'} />
+            <OptionButton label="Light" disabled />
+          </div>
+        </Row>
+        <Row label="Traffic row colors">
+          <div className="flex gap-2">
+            <OptionButton
+              label="Off"
+              active={trafficRowColorMode === 'off'}
+              onClick={() => setTrafficRowColorMode('off')}
+            />
+            <OptionButton
+              label="By Status"
+              active={trafficRowColorMode === 'status'}
+              onClick={() => setTrafficRowColorMode('status')}
+            />
+            <OptionButton
+              label="By Content Type"
+              active={trafficRowColorMode === 'content-type'}
+              onClick={() => setTrafficRowColorMode('content-type')}
+            />
           </div>
         </Row>
       </Section>
@@ -270,15 +297,28 @@ function CertBadge({ status }: { status: 'checking' | 'installed' | 'not-install
   );
 }
 
-function ThemeOption({ label, active, disabled }: { label: string; active?: boolean; disabled?: boolean }) {
+function OptionButton({
+  label,
+  active,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
   return (
-    <span
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
       className={`px-3 py-1.5 rounded text-sm transition-colors
         ${active ? 'bg-pb-accent/20 text-pb-accent border border-pb-accent/40' : ''}
         ${disabled ? 'text-pb-text-dim border border-pb-border opacity-50 cursor-not-allowed' : ''}
         ${!active && !disabled ? 'text-pb-text border border-pb-border hover:bg-pb-surface-hover cursor-pointer' : ''}`}
     >
       {label}{disabled ? ' (coming soon)' : ''}
-    </span>
+    </button>
   );
 }

--- a/src/renderer/components/traffic/TrafficList.tsx
+++ b/src/renderer/components/traffic/TrafficList.tsx
@@ -4,6 +4,7 @@ import TrafficRow from './TrafficRow';
 import ContextMenu from './ContextMenu';
 import type { ContextMenuItem } from './ContextMenu';
 import { flowToCurl } from '../../utils/curl';
+import { useAppStore } from '../../stores/app';
 import { useRulesStore } from '../../stores/rules';
 import type { HttpFlow, HttpHeaders } from '../../../shared/types';
 
@@ -135,6 +136,7 @@ function saveVisibleColumns(columns: Set<ColumnKey>) {
 }
 
 export default function TrafficList({ flows, selectedId, onSelect }: Props) {
+  const trafficRowColorMode = useAppStore((state) => state.trafficRowColorMode);
   const [sort, setSort] = useState<SortState>({ column: null, direction: 'asc' });
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [visibleColumns, setVisibleColumns] = useState<Set<ColumnKey>>(loadVisibleColumns);
@@ -369,6 +371,7 @@ export default function TrafficList({ flows, selectedId, onSelect }: Props) {
             onSelect={onSelect}
             onContextMenu={handleContextMenu}
             visibleColumns={visibleColumns}
+            colorMode={trafficRowColorMode}
             columnKey={columnKey}
           />
         )}

--- a/src/renderer/components/traffic/TrafficRow.tsx
+++ b/src/renderer/components/traffic/TrafficRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { HttpFlow } from '../../../shared/types';
 import type { ColumnKey } from './TrafficList';
+import { getTrafficRowAccentColor, type TrafficRowColorMode } from '../../utils/traffic-row-colors';
 
 interface Props {
   flow: HttpFlow;
@@ -8,6 +9,7 @@ interface Props {
   onSelect: (id: string) => void;
   onContextMenu?: (e: React.MouseEvent, flow: HttpFlow) => void;
   visibleColumns: Set<ColumnKey>;
+  colorMode: TrafficRowColorMode;
   /** Stable string key for memo comparison (avoids Set reference issues) */
   columnKey?: string;
 }
@@ -74,16 +76,18 @@ function getContentType(headers?: Record<string, any>): string {
   return ct.split(';')[0].split('/').pop() || '—';
 }
 
-function TrafficRowInner({ flow, selected, onSelect, onContextMenu, visibleColumns }: Props) {
+function TrafficRowInner({ flow, selected, onSelect, onContextMenu, visibleColumns, colorMode }: Props) {
   const pathPart = flow.request.url.replace(/^https?:\/\/[^/]+/, '');
   const v = visibleColumns;
+  const accentColor = getTrafficRowAccentColor(flow, colorMode);
 
   return (
     <div
       onClick={() => onSelect(flow.id)}
       onContextMenu={(e) => onContextMenu?.(e, flow)}
-      className={`flex items-center h-8 px-3 text-xs cursor-pointer border-b border-pb-border/30 transition-colors
+      className={`flex items-center h-8 px-3 text-xs cursor-pointer border-b border-l-[3px] border-pb-border/30 transition-colors
         ${selected ? 'bg-pb-accent/15 text-pb-text' : 'hover:bg-pb-surface-hover text-pb-text'}`}
+      style={{ borderLeftColor: accentColor }}
     >
       {v.has('timestamp') && (
         <span className="w-20 font-mono text-pb-text-dim" title={new Date(flow.createdAt || flow.request.timestamp).toISOString()}>
@@ -162,6 +166,7 @@ const TrafficRow = React.memo(TrafficRowInner, (prev, next) => {
     prev.selected === next.selected &&
     prev.onSelect === next.onSelect &&
     prev.onContextMenu === next.onContextMenu &&
+    prev.colorMode === next.colorMode &&
     prev.columnKey === next.columnKey
   );
 });

--- a/src/renderer/stores/app.ts
+++ b/src/renderer/stores/app.ts
@@ -1,14 +1,48 @@
 import { create } from 'zustand';
+import type { TrafficRowColorMode } from '../utils/traffic-row-colors';
+
+const TRAFFIC_ROW_COLOR_MODE_STORAGE_KEY = 'proxyboy-traffic-row-colors';
+
+function loadTrafficRowColorMode(): TrafficRowColorMode {
+  if (typeof window === 'undefined') {
+    return 'off';
+  }
+
+  try {
+    const raw = window.localStorage.getItem(TRAFFIC_ROW_COLOR_MODE_STORAGE_KEY);
+    if (raw === 'status' || raw === 'content-type' || raw === 'off') {
+      return raw;
+    }
+  } catch {
+    // Ignore storage access failures and fall back to the default.
+  }
+
+  return 'off';
+}
+
+function persistTrafficRowColorMode(mode: TrafficRowColorMode): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(TRAFFIC_ROW_COLOR_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Ignore storage access failures so settings UI remains usable.
+  }
+}
 
 interface AppState {
   proxyRunning: boolean;
   proxyPort: number;
   noCacheEnabled: boolean;
   theme: 'dark' | 'light';
+  trafficRowColorMode: TrafficRowColorMode;
   setProxyRunning: (running: boolean) => void;
   setProxyPort: (port: number) => void;
   setNoCacheEnabled: (enabled: boolean) => void;
   setTheme: (theme: 'dark' | 'light') => void;
+  setTrafficRowColorMode: (mode: TrafficRowColorMode) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -16,8 +50,13 @@ export const useAppStore = create<AppState>((set) => ({
   proxyPort: 9090,
   noCacheEnabled: false,
   theme: 'dark',
+  trafficRowColorMode: loadTrafficRowColorMode(),
   setProxyRunning: (running) => set({ proxyRunning: running }),
   setProxyPort: (port) => set({ proxyPort: port }),
   setNoCacheEnabled: (enabled) => set({ noCacheEnabled: enabled }),
   setTheme: (theme) => set({ theme }),
+  setTrafficRowColorMode: (trafficRowColorMode) => {
+    persistTrafficRowColorMode(trafficRowColorMode);
+    set({ trafficRowColorMode });
+  },
 }));

--- a/src/renderer/utils/traffic-row-colors.test.ts
+++ b/src/renderer/utils/traffic-row-colors.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { HttpFlow } from '../../shared/types';
+import { getTrafficRowAccentColor, type TrafficRowColorMode } from './traffic-row-colors';
+
+interface FlowOverrides extends Omit<Partial<HttpFlow>, 'request' | 'response'> {
+  request?: Partial<HttpFlow['request']>;
+  response?: Partial<NonNullable<HttpFlow['response']>>;
+}
+
+function createFlow(overrides?: FlowOverrides): HttpFlow {
+  const hasResponseOverride = Boolean(overrides && Object.prototype.hasOwnProperty.call(overrides, 'response'));
+  const { request: requestOverrides, response: responseOverrides, ...flowOverrides } = overrides || {};
+
+  return {
+    id: 'flow-1',
+    request: {
+      id: 'req-1',
+      method: 'GET',
+      url: 'https://example.com/data',
+      protocol: 'https',
+      host: 'example.com',
+      path: '/data',
+      headers: {},
+      bodySize: 0,
+      timestamp: Date.now(),
+      ...(requestOverrides || {}),
+    },
+    response: hasResponseOverride
+      ? responseOverrides as HttpFlow['response']
+      : {
+          id: 'res-1',
+          requestId: 'req-1',
+          statusCode: 200,
+          statusMessage: 'OK',
+          headers: { 'content-type': 'application/json' },
+          bodySize: 0,
+          timestamp: Date.now(),
+          duration: 100,
+          ...(responseOverrides || {}),
+        },
+    state: 'complete',
+    tags: [],
+    createdAt: Date.now(),
+    ...flowOverrides,
+  };
+}
+
+describe('getTrafficRowAccentColor', () => {
+  it('returns transparent when row colors are off', () => {
+    expect(getTrafficRowAccentColor(createFlow(), 'off')).toBe('transparent');
+  });
+
+  it('maps status mode to success, info, warning, and error accents', () => {
+    expect(getTrafficRowAccentColor(createFlow(), 'status')).toBe('var(--color-pb-success)');
+    expect(getTrafficRowAccentColor(createFlow({ response: { statusCode: 302 } }), 'status')).toBe('var(--color-pb-info)');
+    expect(getTrafficRowAccentColor(createFlow({ response: { statusCode: 404 } }), 'status')).toBe('var(--color-pb-warning)');
+    expect(getTrafficRowAccentColor(createFlow({ response: { statusCode: 503 } }), 'status')).toBe('var(--color-pb-error)');
+  });
+
+  it('uses a muted accent for pending flows in either mode', () => {
+    expect(getTrafficRowAccentColor(createFlow({ response: undefined, state: 'pending' }), 'status')).toBe('var(--color-pb-text-dim)');
+    expect(getTrafficRowAccentColor(createFlow({ response: undefined, state: 'pending' }), 'content-type')).toBe('var(--color-pb-text-dim)');
+  });
+
+  it('maps content-type mode to accessible category colors', () => {
+    const cases: Array<[string, TrafficRowColorMode, string]> = [
+      ['application/json', 'content-type', 'var(--color-pb-info)'],
+      ['text/html', 'content-type', 'var(--color-pb-accent)'],
+      ['image/png', 'content-type', 'var(--color-pb-success)'],
+      ['text/plain', 'content-type', 'var(--color-pb-warning)'],
+    ];
+
+    for (const [contentType, mode, expected] of cases) {
+      expect(
+        getTrafficRowAccentColor(createFlow({ response: { headers: { 'content-type': contentType } } }), mode),
+      ).toBe(expected);
+    }
+  });
+});
+

--- a/src/renderer/utils/traffic-row-colors.ts
+++ b/src/renderer/utils/traffic-row-colors.ts
@@ -1,0 +1,69 @@
+import type { HttpFlow, HttpHeaders } from '../../shared/types';
+
+export type TrafficRowColorMode = 'off' | 'status' | 'content-type';
+
+function getContentType(headers?: HttpHeaders): string {
+  if (!headers) return '';
+  return String(headers['content-type'] || '').toLowerCase();
+}
+
+function getStatusAccentColor(flow: HttpFlow): string {
+  if (flow.state === 'error' || flow.state === 'blocked') {
+    return 'var(--color-pb-error)';
+  }
+
+  const status = flow.response?.statusCode;
+  if (!status) {
+    return 'var(--color-pb-text-dim)';
+  }
+  if (status < 300) {
+    return 'var(--color-pb-success)';
+  }
+  if (status < 400) {
+    return 'var(--color-pb-info)';
+  }
+  if (status < 500) {
+    return 'var(--color-pb-warning)';
+  }
+  return 'var(--color-pb-error)';
+}
+
+function getContentTypeAccentColor(flow: HttpFlow): string {
+  if (flow.state === 'error' || flow.state === 'blocked') {
+    return 'var(--color-pb-error)';
+  }
+
+  const contentType = getContentType(flow.response?.headers);
+  if (!contentType) {
+    return 'var(--color-pb-text-dim)';
+  }
+  if (contentType.includes('json') || contentType.includes('javascript') || contentType.includes('graphql')) {
+    return 'var(--color-pb-info)';
+  }
+  if (contentType.includes('html') || contentType.includes('css')) {
+    return 'var(--color-pb-accent)';
+  }
+  if (contentType.includes('image') || contentType.includes('font')) {
+    return 'var(--color-pb-success)';
+  }
+  if (contentType.includes('xml') || contentType.includes('text')) {
+    return 'var(--color-pb-warning)';
+  }
+  if (contentType.includes('audio') || contentType.includes('video')) {
+    return 'var(--color-pb-warning)';
+  }
+  return 'var(--color-pb-accent)';
+}
+
+export function getTrafficRowAccentColor(flow: HttpFlow, mode: TrafficRowColorMode): string {
+  switch (mode) {
+    case 'status':
+      return getStatusAccentColor(flow);
+    case 'content-type':
+      return getContentTypeAccentColor(flow);
+    case 'off':
+    default:
+      return 'transparent';
+  }
+}
+


### PR DESCRIPTION
## Summary

- add configurable traffic row accents with off, by-status, and by-content-type modes
- persist the row color preference in the renderer app store and expose it in Settings
- cover the accent color mapping with focused renderer tests

Closes #16
