### PR TITLE
feat: Multiple tabs / workspaces (#17)

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -31,8 +31,16 @@ import {
   deleteFlow as deleteStoredFlow,
   getAppSetting,
   setAppSetting,
+  getSessions,
+  createSession,
+  renameSession as dbRenameSession,
+  deleteSession as dbDeleteSession,
+  getActiveSessionId,
+  setActiveSessionId,
+  getFlowById,
 } from '../storage/queries';
 import * as fs from 'fs';
+import type { Session } from '../../shared/types';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
 declare const MAIN_WINDOW_VITE_NAME: string;
@@ -136,6 +144,14 @@ export function registerIpcHandlers(
   const updateManager = new UpdateManager('pjperez/proxyboy', getAppSetting(AUTO_UPDATE_ENABLED_KEY) !== 'false');
   let protobufSettings: ProtobufSettings = DEFAULT_PROTOBUF_SETTINGS;
   let pendingFlowUpdates = new Map<string, TrafficFlowUpdate>();
+
+  // Ensure default session exists
+  const existingSessions = getSessions();
+  if (!existingSessions.some(s => s.id === 'default')) {
+    const now = Date.now();
+    createSession({ id: 'default', name: 'Default', createdAt: now, updatedAt: now });
+  }
+  let activeSessionId = getActiveSessionId() || 'default';
   let flowUpdateTimer: NodeJS.Timeout | null = null;
 
   // Broadcast to all windows that care about agent events
@@ -367,7 +383,8 @@ export function registerIpcHandlers(
   // Traffic
   ipcMain.handle(IPC_CHANNELS.TRAFFIC_GET_FLOWS, (_event) => {
     try {
-      return proxyEngine.getFlows().map(sanitizeFlow);
+      const dbFlows = getStoredFlows(5000, 0, activeSessionId);
+      return dbFlows.map(sanitizeFlow);
     } catch (error: any) {
       return { success: false, error: error.message };
     }
@@ -376,7 +393,10 @@ export function registerIpcHandlers(
   ipcMain.handle(IPC_CHANNELS.TRAFFIC_GET_FLOW, (_event, id: string) => {
     try {
       const flow = proxyEngine.getFlow(id);
-      return flow ? sanitizeFlow(flow) : null;
+      if (flow) return sanitizeFlow(flow);
+      // Fallback to DB for flows cleared from engine memory
+      const dbFlow = getFlowById(id);
+      return dbFlow ? sanitizeFlow(dbFlow) : null;
     } catch (error: any) {
       return { success: false, error: error.message };
     }
@@ -385,7 +405,7 @@ export function registerIpcHandlers(
   ipcMain.handle(IPC_CHANNELS.TRAFFIC_CLEAR, () => {
     try {
       proxyEngine.clearFlows();
-      clearAllFlows();
+      clearAllFlows(activeSessionId);
       return { success: true };
     } catch (error: any) {
       return { success: false, error: error.message };
@@ -1017,6 +1037,45 @@ export function registerIpcHandlers(
     }
   });
 
+  // Sessions
+  ipcMain.handle(IPC_CHANNELS.SESSION_LIST, () => {
+    return getSessions();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.SESSION_CREATE, (_event, name: string) => {
+    const now = Date.now();
+    const session: Session = {
+      id: randomUUID(),
+      name: name || 'New Tab',
+      createdAt: now,
+      updatedAt: now,
+    };
+    createSession(session);
+    return session;
+  });
+
+  ipcMain.handle(IPC_CHANNELS.SESSION_RENAME, (_event, { id, name }: { id: string; name: string }) => {
+    dbRenameSession(id, name);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.SESSION_DELETE, (_event, id: string) => {
+    if (id === 'default') return;
+    dbDeleteSession(id);
+    if (activeSessionId === id) {
+      activeSessionId = 'default';
+      setActiveSessionId('default');
+    }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.SESSION_SET_ACTIVE, (_event, id: string) => {
+    activeSessionId = id;
+    setActiveSessionId(id);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.SESSION_GET_ACTIVE, () => {
+    return activeSessionId;
+  });
+
   // Forward proxy events to renderer
   proxyEngine.on('flow:start', (flow: HttpFlow) => {
     mainWindow.webContents.send(IPC_CHANNELS.TRAFFIC_NEW_FLOW, sanitizeFlow(flow));
@@ -1029,7 +1088,7 @@ export function registerIpcHandlers(
   proxyEngine.on('flow:complete', (flow: HttpFlow) => {
     pendingFlowUpdates.delete(flow.id);
     mainWindow.webContents.send(IPC_CHANNELS.TRAFFIC_FLOW_COMPLETE, sanitizeFlow(flow));
-    saveFlow(flow);
+    saveFlow(flow, activeSessionId);
   });
 
   // Forward breakpoint events to renderer

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '../shared/constants';
-import type { BreakpointPauseMessage, BreakpointResumeMessage, ProxyState, HttpFlow, Rule, FilterCriteria, CaptureFilterMode, ComposerRequest, AppUpdateState, ScriptRule, ScriptTestResult, TrafficFlowUpdate } from '../shared/types';
+import type { BreakpointPauseMessage, BreakpointResumeMessage, ProxyState, HttpFlow, Rule, FilterCriteria, CaptureFilterMode, ComposerRequest, AppUpdateState, ScriptRule, ScriptTestResult, TrafficFlowUpdate, Session } from '../shared/types';
 import type { ThrottleSettings } from '../shared/throttle';
 import type { UpstreamProxySettings } from '../shared/upstream-proxy';
 import type { ProtobufDecodeRequest, ProtobufSettings } from '../shared/protobuf';
@@ -154,6 +154,16 @@ const api = {
     getConfig: () => ipcRenderer.invoke(IPC_CHANNELS.DNS_GET_CONFIG),
     setServers: (servers: string[]) => ipcRenderer.invoke(IPC_CHANNELS.DNS_SET_SERVERS, servers),
     clearCache: () => ipcRenderer.invoke(IPC_CHANNELS.DNS_CLEAR_CACHE),
+  },
+
+  // Sessions
+  sessions: {
+    list: (): Promise<Session[]> => ipcRenderer.invoke(IPC_CHANNELS.SESSION_LIST),
+    create: (name: string): Promise<Session> => ipcRenderer.invoke(IPC_CHANNELS.SESSION_CREATE, name),
+    rename: (id: string, name: string): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.SESSION_RENAME, { id, name }),
+    delete: (id: string): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.SESSION_DELETE, id),
+    setActive: (id: string): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.SESSION_SET_ACTIVE, id),
+    getActive: (): Promise<string> => ipcRenderer.invoke(IPC_CHANNELS.SESSION_GET_ACTIVE),
   },
 };
 

--- a/src/main/storage/database.ts
+++ b/src/main/storage/database.ts
@@ -128,7 +128,7 @@ function initializeSchema(database: SqlJsDatabase): void {
   database.run(`
     CREATE TABLE IF NOT EXISTS app_settings (
       key TEXT PRIMARY KEY,
-      value TEXT NOT NULL
+      value TEXT NOT NULL,
       updated_at INTEGER NOT NULL
     );
   `);
@@ -162,6 +162,9 @@ function initializeSchema(database: SqlJsDatabase): void {
   ensureColumn(database, 'requests', 'graphql_operation_type', 'TEXT');
   ensureColumn(database, 'requests', 'graphql_operation_name', 'TEXT');
   ensureColumn(database, 'responses', 'body_encoding', "TEXT DEFAULT 'utf8'");
+  ensureColumn(database, 'rules', 'updated_at', 'INTEGER NOT NULL DEFAULT 0');
+  ensureColumn(database, 'app_settings', 'updated_at', 'INTEGER NOT NULL DEFAULT 0');
+  ensureColumn(database, 'agent_conversations', 'updated_at', 'INTEGER NOT NULL DEFAULT 0');
 }
 
 function ensureColumn(database: SqlJsDatabase, table: string, column: string, definition: string): void {

--- a/src/main/storage/database.ts
+++ b/src/main/storage/database.ts
@@ -151,13 +151,23 @@ function initializeSchema(database: SqlJsDatabase): void {
       FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON DELETE CASCADE
     );
   `);
+  database.run(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
   database.run('CREATE INDEX IF NOT EXISTS idx_requests_flow_id ON requests(flow_id);');
   database.run('CREATE INDEX IF NOT EXISTS idx_responses_flow_id ON responses(flow_id);');
   database.run('CREATE INDEX IF NOT EXISTS idx_requests_url ON requests(url);');
   database.run('CREATE INDEX IF NOT EXISTS idx_requests_method ON requests(method);');
   database.run('CREATE INDEX IF NOT EXISTS idx_responses_status_code ON responses(status_code);');
   database.run('CREATE INDEX IF NOT EXISTS idx_agent_messages_conversation ON agent_messages(conversation_id);');
+  database.run('CREATE INDEX IF NOT EXISTS idx_flows_session_id ON flows(session_id);');
   ensureColumn(database, 'flows', 'timing', 'TEXT');
+  ensureColumn(database, 'flows', 'session_id', 'TEXT');
   ensureColumn(database, 'requests', 'body_encoding', "TEXT DEFAULT 'utf8'");
   ensureColumn(database, 'requests', 'graphql_operation_type', 'TEXT');
   ensureColumn(database, 'requests', 'graphql_operation_name', 'TEXT');

--- a/src/main/storage/queries.ts
+++ b/src/main/storage/queries.ts
@@ -1,5 +1,5 @@
 import { getDatabase, schedulePersist } from './database';
-import { FlowTiming, HttpFlow, HttpRequest, HttpResponse, Rule, StoredBody } from '../../shared/types';
+import { FlowTiming, HttpFlow, HttpRequest, HttpResponse, Rule, Session, StoredBody } from '../../shared/types';
 import { annotateGraphQLRequest } from '../../shared/graphql';
 
 function isProbablyTextBuffer(buf: Buffer): boolean {
@@ -31,14 +31,14 @@ function decodeBody(data?: string, encoding?: string): Buffer | string | undefin
   return data;
 }
 
-export function saveFlow(flow: HttpFlow): void {
+export function saveFlow(flow: HttpFlow, sessionId?: string): void {
   const db = getDatabase();
   const requestBody = encodeBody(flow.request.body);
   const responseBody = encodeBody(flow.response?.body);
 
   db.run(
-    `INSERT OR REPLACE INTO flows (id, state, tags, notes, created_at, timing) VALUES (?, ?, ?, ?, ?, ?)`,
-    [flow.id, flow.state, JSON.stringify(flow.tags), flow.notes || null, flow.createdAt, flow.timing ? JSON.stringify(flow.timing) : null],
+    `INSERT OR REPLACE INTO flows (id, state, tags, notes, created_at, timing, session_id) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [flow.id, flow.state, JSON.stringify(flow.tags), flow.notes || null, flow.createdAt, flow.timing ? JSON.stringify(flow.timing) : null, sessionId || null],
   );
 
   db.run(
@@ -92,7 +92,11 @@ function queryFlows(sql: string, params: any[] = []): HttpFlow[] {
   return flows;
 }
 
-export function getFlows(limit = 1000, offset = 0): HttpFlow[] {
+export function getFlows(limit = 1000, offset = 0, sessionId?: string): HttpFlow[] {
+  const sessionFilter = sessionId ? 'AND f.session_id = ?' : '';
+  const params = sessionId ? [limit, offset, sessionId] : [limit, offset];
+  // Place sessionId params before limit/offset in the WHERE clause
+  const reorderedParams = sessionId ? [sessionId, limit, offset] : [limit, offset];
   return queryFlows(`
     SELECT f.id, f.state, f.tags, f.notes, f.created_at, f.timing,
            r.id as req_id, r.method, r.url, r.protocol, r.host, r.path,
@@ -105,9 +109,28 @@ export function getFlows(limit = 1000, offset = 0): HttpFlow[] {
     FROM flows f
     JOIN requests r ON r.flow_id = f.id
     LEFT JOIN responses res ON res.flow_id = f.id
+    WHERE 1=1 ${sessionFilter}
     ORDER BY f.created_at DESC
     LIMIT ? OFFSET ?
-  `, [limit, offset]);
+  `, reorderedParams);
+}
+
+export function getFlowById(id: string): HttpFlow | null {
+  const results = queryFlows(`
+    SELECT f.id, f.state, f.tags, f.notes, f.created_at, f.timing,
+           r.id as req_id, r.method, r.url, r.protocol, r.host, r.path,
+           r.headers as req_headers, r.body as req_body, r.body_encoding as req_body_encoding, r.body_size as req_body_size,
+           r.graphql_operation_type as req_graphql_operation_type, r.graphql_operation_name as req_graphql_operation_name,
+           r.timestamp as req_timestamp,
+           res.id as res_id, res.status_code, res.status_message,
+           res.headers as res_headers, res.body as res_body, res.body_encoding as res_body_encoding, res.body_size as res_body_size,
+           res.timestamp as res_timestamp, res.duration
+    FROM flows f
+    JOIN requests r ON r.flow_id = f.id
+    LEFT JOIN responses res ON res.flow_id = f.id
+    WHERE f.id = ?
+  `, [id]);
+  return results.length > 0 ? results[0] : null;
 }
 
 export function searchFlows(query: string): HttpFlow[] {
@@ -152,11 +175,17 @@ export function getErrorFlows(): HttpFlow[] {
   `);
 }
 
-export function clearAllFlows(): void {
+export function clearAllFlows(sessionId?: string): void {
   const db = getDatabase();
-  db.run('DELETE FROM responses');
-  db.run('DELETE FROM requests');
-  db.run('DELETE FROM flows');
+  if (sessionId) {
+    db.run('DELETE FROM responses WHERE flow_id IN (SELECT id FROM flows WHERE session_id = ?)', [sessionId]);
+    db.run('DELETE FROM requests WHERE flow_id IN (SELECT id FROM flows WHERE session_id = ?)', [sessionId]);
+    db.run('DELETE FROM flows WHERE session_id = ?', [sessionId]);
+  } else {
+    db.run('DELETE FROM responses');
+    db.run('DELETE FROM requests');
+    db.run('DELETE FROM flows');
+  }
   schedulePersist();
 }
 
@@ -274,4 +303,55 @@ function rowToFlow(row: any): HttpFlow {
     createdAt: row.created_at,
     timing: row.timing ? JSON.parse(row.timing as string) as FlowTiming : undefined,
   };
+}
+
+// Session CRUD
+export function getSessions(): Session[] {
+  const db = getDatabase();
+  const stmt = db.prepare('SELECT id, name, created_at, updated_at FROM sessions ORDER BY created_at ASC');
+  const sessions: Session[] = [];
+  while (stmt.step()) {
+    const row = stmt.getAsObject();
+    sessions.push({
+      id: row.id as string,
+      name: row.name as string,
+      createdAt: row.created_at as number,
+      updatedAt: row.updated_at as number,
+    });
+  }
+  stmt.free();
+  return sessions;
+}
+
+export function createSession(session: Session): void {
+  const db = getDatabase();
+  db.run(
+    'INSERT INTO sessions (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)',
+    [session.id, session.name, session.createdAt, session.updatedAt],
+  );
+  schedulePersist();
+}
+
+export function renameSession(id: string, name: string): void {
+  const db = getDatabase();
+  db.run(
+    'UPDATE sessions SET name = ?, updated_at = ? WHERE id = ?',
+    [name, Date.now(), id],
+  );
+  schedulePersist();
+}
+
+export function deleteSession(id: string): void {
+  const db = getDatabase();
+  clearAllFlows(id);
+  db.run('DELETE FROM sessions WHERE id = ?', [id]);
+  schedulePersist();
+}
+
+export function getActiveSessionId(): string | null {
+  return getAppSetting('active_session_id');
+}
+
+export function setActiveSessionId(id: string): void {
+  setAppSetting('active_session_id', id);
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,8 +18,10 @@ import BreakpointPauseDialog from './components/rules/BreakpointPauseDialog';
 import { useTrafficStore } from './stores/traffic';
 import { useRulesStore } from './stores/rules';
 import { useAppStore } from './stores/app';
+import { useSessionStore } from './stores/sessions';
 import { flowToCurl } from './utils/curl';
 import { clearTrafficFlows, deleteTrafficFlow, exportHarFile, importHarFile, toggleProxyRecording } from './utils/app-actions';
+import TabBar from './components/layout/TabBar';
 import { getNextSelectedFlowIdAfterDelete } from './utils/shortcuts';
 import { applyThemePreference, watchSystemTheme } from './utils/theme';
 import { normalizeThrottleSettings } from '../shared/throttle';
@@ -153,11 +155,34 @@ function MainApp() {
       setUpdateState(state);
     });
 
-    api.traffic.getFlows().then((loadedFlows: any[]) => {
-      if (Array.isArray(loadedFlows)) {
-        setFlows(loadedFlows);
+    // Load sessions first, then load flows for the active session
+    const initSessions = async () => {
+      try {
+        const [sessions, activeId] = await Promise.all([
+          api.sessions.list(),
+          api.sessions.getActive(),
+        ]);
+        if (Array.isArray(sessions) && sessions.length > 0) {
+          useSessionStore.getState().setSessions(sessions);
+        }
+        if (activeId) {
+          useSessionStore.getState().setActiveSessionId(activeId);
+        }
+      } catch {
+        // ignore
       }
-    }).catch(() => {});
+
+      // Load flows after session context is established
+      try {
+        const loadedFlows = await api.traffic.getFlows();
+        if (Array.isArray(loadedFlows)) {
+          setFlows(loadedFlows);
+        }
+      } catch {
+        // ignore
+      }
+    };
+    void initSessions();
 
     api.app.getUpdateState().then((state: any) => {
       if (state?.currentVersion) {
@@ -535,6 +560,7 @@ function MainApp() {
         <div className="flex flex-col flex-1 overflow-hidden">
           {selectedView === 'traffic' && (
             <>
+              <TabBar />
               <FilterBar />
               <div className="flex flex-1 overflow-hidden">
                 <div className={`${selectedFlow ? 'w-1/2' : 'w-full'} overflow-hidden border-r border-pb-border`}>

--- a/src/renderer/components/layout/TabBar.tsx
+++ b/src/renderer/components/layout/TabBar.tsx
@@ -1,0 +1,155 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { useSessionStore } from '../../stores/sessions';
+import { useTrafficStore } from '../../stores/traffic';
+
+export default function TabBar() {
+  const { sessions, activeSessionId, setActiveSessionId, addSession, removeSession, renameSession } = useSessionStore();
+  const setFlows = useTrafficStore(s => s.setFlows);
+  const clearFlows = useTrafficStore(s => s.clearFlows);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const switchGenRef = useRef(0);
+
+  useEffect(() => {
+    if (editingId && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editingId]);
+
+  const handleSwitchSession = useCallback(async (id: string) => {
+    if (id === activeSessionId) return;
+    const api = window.proxyboy;
+    if (!api) return;
+
+    const gen = ++switchGenRef.current;
+    await api.sessions.setActive(id);
+    setActiveSessionId(id);
+    clearFlows();
+
+    try {
+      const flows = await api.traffic.getFlows();
+      // Discard stale response if another switch happened
+      if (switchGenRef.current !== gen) return;
+      if (Array.isArray(flows)) {
+        setFlows(flows);
+      }
+    } catch {
+      // ignore
+    }
+  }, [activeSessionId, clearFlows, setActiveSessionId, setFlows]);
+
+  const handleCreateSession = useCallback(async () => {
+    const api = window.proxyboy;
+    if (!api) return;
+
+    const session = await api.sessions.create('New Tab');
+    addSession(session);
+    await handleSwitchSession(session.id);
+  }, [addSession, handleSwitchSession]);
+
+  const handleDeleteSession = useCallback(async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    if (id === 'default') return;
+    const api = window.proxyboy;
+    if (!api) return;
+
+    const wasActive = activeSessionId === id;
+
+    // Update frontend state first to avoid inconsistency window
+    removeSession(id);
+    if (wasActive) {
+      setActiveSessionId('default');
+      clearFlows();
+    }
+
+    // Then sync to backend
+    await api.sessions.delete(id);
+    if (wasActive) {
+      await api.sessions.setActive('default');
+      try {
+        const flows = await api.traffic.getFlows();
+        if (Array.isArray(flows)) {
+          setFlows(flows);
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }, [activeSessionId, clearFlows, removeSession, setActiveSessionId, setFlows]);
+
+  const startRenaming = useCallback((e: React.MouseEvent, id: string, currentName: string) => {
+    e.preventDefault();
+    setEditingId(id);
+    setEditingName(currentName);
+  }, []);
+
+  const commitRename = useCallback(async () => {
+    if (!editingId) return;
+    const trimmed = editingName.trim();
+    if (trimmed) {
+      const api = window.proxyboy;
+      if (api) {
+        await api.sessions.rename(editingId, trimmed);
+      }
+      renameSession(editingId, trimmed);
+    }
+    setEditingId(null);
+  }, [editingId, editingName, renameSession]);
+
+  const handleInputKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      void commitRename();
+    } else if (e.key === 'Escape') {
+      setEditingId(null);
+    }
+  }, [commitRename]);
+
+  return (
+    <div className="flex items-center h-9 bg-pb-surface border-b border-pb-border px-1 gap-0.5 overflow-x-auto shrink-0">
+      {sessions.map(session => (
+        <div
+          key={session.id}
+          onClick={() => handleSwitchSession(session.id)}
+          onDoubleClick={(e) => startRenaming(e, session.id, session.name)}
+          className={`group flex items-center gap-1 px-3 h-7 rounded text-xs cursor-pointer select-none shrink-0 transition-colors
+            ${activeSessionId === session.id
+              ? 'bg-pb-accent/20 text-pb-accent'
+              : 'text-pb-text-dim hover:bg-pb-surface-hover hover:text-pb-text'
+            }`}
+        >
+          {editingId === session.id ? (
+            <input
+              ref={inputRef}
+              value={editingName}
+              onChange={(e) => setEditingName(e.target.value)}
+              onBlur={() => void commitRename()}
+              onKeyDown={handleInputKeyDown}
+              className="bg-transparent border border-pb-border rounded px-1 text-xs w-24 outline-none text-pb-text"
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <span className="truncate max-w-[120px]">{session.name}</span>
+          )}
+          {session.id !== 'default' && editingId !== session.id && (
+            <button
+              onClick={(e) => handleDeleteSession(e, session.id)}
+              className="opacity-0 group-hover:opacity-100 ml-1 text-pb-text-dim hover:text-pb-text transition-opacity"
+              title="Close tab"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      ))}
+      <button
+        onClick={handleCreateSession}
+        className="flex items-center justify-center w-7 h-7 rounded text-pb-text-dim hover:bg-pb-surface-hover hover:text-pb-text transition-colors shrink-0"
+        title="New tab"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/stores/sessions.test.ts
+++ b/src/renderer/stores/sessions.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSessionStore } from './sessions';
+import type { Session } from '../../shared/types';
+
+function createSession(overrides?: Partial<Session>): Session {
+  return {
+    id: 'test-1',
+    name: 'Test Session',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('useSessionStore', () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      sessions: [],
+      activeSessionId: 'default',
+    });
+  });
+
+  describe('setSessions', () => {
+    it('replaces all sessions', () => {
+      const sessions = [
+        createSession({ id: 'default', name: 'Default' }),
+        createSession({ id: 's1', name: 'Session 1' }),
+      ];
+      useSessionStore.getState().setSessions(sessions);
+      expect(useSessionStore.getState().sessions).toEqual(sessions);
+    });
+  });
+
+  describe('setActiveSessionId', () => {
+    it('updates the active session id', () => {
+      useSessionStore.getState().setActiveSessionId('s1');
+      expect(useSessionStore.getState().activeSessionId).toBe('s1');
+    });
+  });
+
+  describe('addSession', () => {
+    it('appends a new session', () => {
+      const existing = createSession({ id: 'default', name: 'Default' });
+      useSessionStore.getState().setSessions([existing]);
+
+      const newSession = createSession({ id: 's2', name: 'New' });
+      useSessionStore.getState().addSession(newSession);
+
+      expect(useSessionStore.getState().sessions).toHaveLength(2);
+      expect(useSessionStore.getState().sessions[1].id).toBe('s2');
+    });
+  });
+
+  describe('removeSession', () => {
+    it('removes a session by id', () => {
+      const sessions = [
+        createSession({ id: 'default', name: 'Default' }),
+        createSession({ id: 's1', name: 'Session 1' }),
+        createSession({ id: 's2', name: 'Session 2' }),
+      ];
+      useSessionStore.getState().setSessions(sessions);
+
+      useSessionStore.getState().removeSession('s1');
+      const remaining = useSessionStore.getState().sessions;
+      expect(remaining).toHaveLength(2);
+      expect(remaining.map(s => s.id)).toEqual(['default', 's2']);
+    });
+
+    it('does not crash when removing a non-existent id', () => {
+      const sessions = [createSession({ id: 'default', name: 'Default' })];
+      useSessionStore.getState().setSessions(sessions);
+
+      useSessionStore.getState().removeSession('non-existent');
+      expect(useSessionStore.getState().sessions).toHaveLength(1);
+    });
+  });
+
+  describe('renameSession', () => {
+    it('renames a session', () => {
+      const sessions = [
+        createSession({ id: 'default', name: 'Default' }),
+        createSession({ id: 's1', name: 'Old Name' }),
+      ];
+      useSessionStore.getState().setSessions(sessions);
+
+      useSessionStore.getState().renameSession('s1', 'New Name');
+      const renamed = useSessionStore.getState().sessions.find(s => s.id === 's1');
+      expect(renamed?.name).toBe('New Name');
+    });
+
+    it('updates the updatedAt timestamp', () => {
+      const oldTime = Date.now() - 10000;
+      const sessions = [
+        createSession({ id: 's1', name: 'Old', updatedAt: oldTime }),
+      ];
+      useSessionStore.getState().setSessions(sessions);
+
+      useSessionStore.getState().renameSession('s1', 'New');
+      const updated = useSessionStore.getState().sessions.find(s => s.id === 's1');
+      expect(updated?.updatedAt).toBeGreaterThan(oldTime);
+    });
+
+    it('does not affect other sessions', () => {
+      const sessions = [
+        createSession({ id: 'default', name: 'Default' }),
+        createSession({ id: 's1', name: 'Session 1' }),
+      ];
+      useSessionStore.getState().setSessions(sessions);
+
+      useSessionStore.getState().renameSession('s1', 'Renamed');
+      expect(useSessionStore.getState().sessions[0].name).toBe('Default');
+    });
+  });
+
+  describe('default session protection', () => {
+    it('default session can still be removed from the store (UI should prevent this)', () => {
+      const sessions = [
+        createSession({ id: 'default', name: 'Default' }),
+        createSession({ id: 's1', name: 'Session 1' }),
+      ];
+      useSessionStore.getState().setSessions(sessions);
+
+      // Store itself doesn't enforce this — the TabBar component does
+      useSessionStore.getState().removeSession('default');
+      expect(useSessionStore.getState().sessions).toHaveLength(1);
+    });
+  });
+
+  describe('active session switching', () => {
+    it('starts with default as active', () => {
+      expect(useSessionStore.getState().activeSessionId).toBe('default');
+    });
+
+    it('can switch active session', () => {
+      useSessionStore.getState().setActiveSessionId('s1');
+      expect(useSessionStore.getState().activeSessionId).toBe('s1');
+    });
+
+    it('can switch back to default', () => {
+      useSessionStore.getState().setActiveSessionId('s1');
+      useSessionStore.getState().setActiveSessionId('default');
+      expect(useSessionStore.getState().activeSessionId).toBe('default');
+    });
+  });
+});

--- a/src/renderer/stores/sessions.ts
+++ b/src/renderer/stores/sessions.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+import type { Session } from '../../shared/types';
+
+interface SessionState {
+  sessions: Session[];
+  activeSessionId: string;
+  setSessions: (sessions: Session[]) => void;
+  setActiveSessionId: (id: string) => void;
+  addSession: (session: Session) => void;
+  removeSession: (id: string) => void;
+  renameSession: (id: string, name: string) => void;
+}
+
+export const useSessionStore = create<SessionState>((set) => ({
+  sessions: [],
+  activeSessionId: 'default',
+  setSessions: (sessions) => set({ sessions }),
+  setActiveSessionId: (activeSessionId) => set({ activeSessionId }),
+  addSession: (session) => set((state) => ({ sessions: [...state.sessions, session] })),
+  removeSession: (id) => set((state) => ({ sessions: state.sessions.filter(s => s.id !== id) })),
+  renameSession: (id, name) => set((state) => ({
+    sessions: state.sessions.map(s => s.id === id ? { ...s, name, updatedAt: Date.now() } : s),
+  })),
+}));

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -71,6 +71,14 @@ export const IPC_CHANNELS = {
   DNS_GET_CONFIG: 'dns:get-config',
   DNS_SET_SERVERS: 'dns:set-servers',
   DNS_CLEAR_CACHE: 'dns:clear-cache',
+
+  // Sessions
+  SESSION_LIST: 'session:list',
+  SESSION_CREATE: 'session:create',
+  SESSION_RENAME: 'session:rename',
+  SESSION_DELETE: 'session:delete',
+  SESSION_SET_ACTIVE: 'session:set-active',
+  SESSION_GET_ACTIVE: 'session:get-active',
 } as const;
 
 export const DEFAULT_PROXY_PORT = 9090;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -302,3 +302,10 @@ export interface ComposerRequest {
   headers: HttpHeaders;
   body?: string;
 }
+
+export interface Session {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+}


### PR DESCRIPTION
Implements issue #17. Adds session-based tab system for organizing proxy traffic into separate workspaces. Includes Session type, IPC channels, database schema, CRUD queries, IPC handlers, preload API, Zustand session store, TabBar component, and App.tsx wiring. Race-safe session switching, DB fallback for detail panel. 12 new tests, 101 total pass. Closes #17