### PR TITLE
Improve non-AI proxy UX toward Proxyman parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,20 @@ ProxyBoy is a man-in-the-middle (MITM) HTTP/HTTPS proxy that captures, inspects,
 - **Upstream Proxy Chaining** — Forward traffic through HTTP or SOCKS5 upstream proxies with bypass patterns and secure credential storage
 - **Cookie Inspector** — Parse request cookies and `Set-Cookie` headers into a structured, searchable view
 - **AI Assistant** — Chat panel powered by GitHub Copilot that can search traffic, analyze patterns, create rules, and export data
-- **Breakpoint Rules** — Pause requests/responses mid-flight, inspect them, then forward or drop
-- **Map Local Rules** — Serve local files instead of remote responses for mocking APIs
+- **Breakpoint Rules** — Pause requests/responses mid-flight, edit method/URL/headers/body/status, then forward or drop
+- **Map Local Rules** — Serve a local file instead of a remote response for mocking APIs
 - **Map Remote Rules** — Forward matching requests to a different upstream host without changing your client
 - **Capture Rules** — Switch between capture-all, allow-list, and block-list modes to control what gets recorded
+- **Host Tree** — Browse captured traffic by host with per-host counts and quick filtering
+- **Query Params & Form Body Views** — Inspect URL query strings and form-encoded bodies in structured tables
+- **Find in Body** — Search within request/response body content in the detail viewer
 - **System Proxy Integration** — Toggle Windows system proxy on/off from the app
 - **HAR Export/Import** — Standard HAR format for sharing captures with other tools
 - **Configurable Columns** — Show/hide columns, sort by any field, timestamps
 - **Body Search** — Include request and response text bodies in traffic filtering when you need deeper search
 - **WebSocket and SSE Inspection** — Capture live WebSocket frames and Server-Sent Events in the traffic detail view
 - **Script Rules** — Run sandboxed JavaScript rules to rewrite requests and responses without leaving the app
-- **Copy as cURL** — Right-click any request to copy it as a cURL command
+- **Copy as cURL / Fetch / PowerShell** — Right-click any request to copy it as cURL, browser Fetch, or PowerShell
 - **Keyboard Shortcuts** — Fast access to proxy control, HAR import/export, filtering, and traffic actions
 - **Theme Modes** — Dark, Light, or System theme selection with live switching
 - **Detachable AI Panel** — Pop the assistant out into its own window
@@ -162,17 +165,19 @@ src/
 
 ## Known Limitations
 
-- **Windows only** — System proxy integration uses Windows registry; the rest could theoretically work cross-platform
-- **No request/response editing in breakpoints** — You can inspect and forward/drop, but not modify (yet)
+- **Windows only** — System proxy integration uses Windows registry; the goal is a strong Windows-native Proxyman-style alternative (AI included), not a half-port of another OS experience
+- **No reverse proxy mode** — ProxyBoy is a forward debugging proxy, not a reverse/ingress proxy
+- **HTTP/2 is not first-class** — Capture and inspection are oriented around HTTP/1.x today
+- **Map Local is single-file only** — Rules map a match to one local file, not a directory tree
 - **SSL inspection quirks** — Some sites with certificate pinning or HSTS preload may not work through the proxy
 - **Cloudflare challenges** — Sites behind Cloudflare browser challenges will typically fail through any MITM proxy
-- **Very limited automated tests** — There is a small test foothold now, but coverage is still far from production-ready 🙃
+- **Limited automated tests** — There is a growing test foothold, but coverage is still far from production-ready 🙃
 
 ---
 
 ## Acknowledgments
 
-- **[Proxyman](https://proxyman.io/)** — The primary inspiration. Seriously, go use Proxyman if you want a polished, reliable proxy tool. It's great.
+- **[Proxyman](https://proxyman.io/)** — The primary inspiration. ProxyBoy aims to be a capable Windows-native alternative even before the AI features; Proxyman remains the polished benchmark if you want a mature cross-platform product today.
 - **[Charles Proxy](https://www.charlesproxy.com/)** and **[Fiddler](https://www.telerik.com/fiddler)** — Other excellent tools in this space
 - **[GitHub Copilot](https://github.com/features/copilot)** — Powers the AI assistant, and also helped build this entire app
 

--- a/src/main/proxy/engine.test.ts
+++ b/src/main/proxy/engine.test.ts
@@ -129,6 +129,26 @@ describe('breakpoint request editing helpers', () => {
     expect(Buffer.from(edited.body as Buffer).toString('utf8')).toContain('goodbye');
   });
 
+  it('applies method and URL path/query edits to the buffered request', () => {
+    const request = createBreakpointRequest();
+
+    const edited = applyBreakpointRequestEdits(request, {
+      method: 'put',
+      url: 'https://api.example.com/v2/graphql?debug=1',
+      headers: {
+        host: 'api.example.com',
+        'content-type': 'application/json',
+      },
+      body: encodeBreakpointBody('{"query":"{ hello }"}'),
+    });
+
+    expect(edited.method).toBe('PUT');
+    expect(edited.host).toBe('api.example.com');
+    expect(edited.path).toBe('/v2/graphql?debug=1');
+    expect(edited.url).toBe('https://api.example.com/v2/graphql?debug=1');
+    expect(edited.headers.host).toBe('api.example.com');
+  });
+
   it('normalizes edited requests for forwarding', () => {
     const edited = prepareBreakpointRequestForForwarding(
       createBreakpointRequest({

--- a/src/main/proxy/engine.ts
+++ b/src/main/proxy/engine.ts
@@ -329,13 +329,49 @@ export function applyBreakpointRequestEdits(
 ): HttpRequest {
   const body = edits ? decodeBreakpointBody(edits.body) : bodyToBuffer(request.body);
   const nextHeaders = edits ? cloneHeaders(edits.headers) : cloneHeaders(request.headers);
-  const host = getEditedHost(nextHeaders, request.host);
+  const method = (edits?.method?.trim() || request.method || 'GET').toUpperCase();
+
+  let protocol = request.protocol;
+  let host = getEditedHost(nextHeaders, request.host);
+  let path = request.path;
+  let url = `${protocol}://${host}${path}`;
+
+  if (edits?.url?.trim()) {
+    try {
+      const parsed = new URL(edits.url.trim());
+      const nextProtocol = parsed.protocol === 'https:' ? 'https' : parsed.protocol === 'http:' ? 'http' : null;
+      if (!nextProtocol) {
+        throw new Error('Unsupported protocol');
+      }
+      if (nextProtocol !== request.protocol) {
+        // Keep the original protocol for the in-flight MITM connection.
+        protocol = request.protocol;
+      } else {
+        protocol = nextProtocol;
+      }
+      host = parsed.host;
+      path = `${parsed.pathname || '/'}${parsed.search}`;
+      url = `${protocol}://${host}${path}`;
+    } catch {
+      // Fall back to host/header-derived URL when the edited URL is invalid.
+      host = getEditedHost(nextHeaders, request.host);
+      path = request.path;
+      url = `${protocol}://${host}${path}`;
+    }
+  } else {
+    host = getEditedHost(nextHeaders, request.host);
+    url = `${protocol}://${host}${path}`;
+  }
+
   setHeaderValue(nextHeaders, 'host', host);
 
   return {
     ...request,
+    method,
+    protocol,
     host,
-    url: `${request.protocol}://${host}${request.path}`,
+    path,
+    url,
     headers: nextHeaders,
     body,
     bodySize: body?.length ?? 0,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import StatusBar from './components/layout/StatusBar';
 import ShortcutHelpDialog from './components/layout/ShortcutHelpDialog';
 import TrafficList from './components/traffic/TrafficList';
 import TrafficDetail from './components/traffic/TrafficDetail';
+import HostTree from './components/traffic/HostTree';
 import FilterBar from './components/filters/FilterBar';
 import AgentPanel from './components/agent/AgentPanel';
 import ComposerPanel from './components/composer/ComposerPanel';
@@ -74,6 +75,7 @@ function MainApp() {
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
   const [agentWidth, setAgentWidth] = useState(384);
   const [selectedFlowId, setSelectedFlowId] = useState<string | null>(null);
+  const [selectedHost, setSelectedHost] = useState<string | null>(null);
 
   const handleAgentResize = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -220,6 +222,12 @@ function MainApp() {
   }, []);
 
   const filteredFlows = useMemo(() => getFilteredFlows(), [flows, filter]);
+  const hostScopedFlows = useMemo(() => {
+    if (!selectedHost) {
+      return filteredFlows;
+    }
+    return filteredFlows.filter((flow) => (flow.request.host || '(unknown)') === selectedHost);
+  }, [filteredFlows, selectedHost]);
   const selectedFlow = useMemo(
     () => selectedFlowId ? flows.find(f => f.id === selectedFlowId) ?? null : null,
     [flows, selectedFlowId]
@@ -241,6 +249,16 @@ function MainApp() {
       setSelectedFlowId(null);
     }
   }, [flows, selectedFlowId]);
+
+  useEffect(() => {
+    if (
+      selectedFlowId &&
+      selectedHost &&
+      !hostScopedFlows.some((flow) => flow.id === selectedFlowId)
+    ) {
+      setSelectedFlowId(null);
+    }
+  }, [hostScopedFlows, selectedFlowId, selectedHost]);
 
   const focusTrafficFilter = useCallback(() => {
     const input = document.getElementById('traffic-filter-input') as HTMLInputElement | null;
@@ -316,10 +334,10 @@ function MainApp() {
       return;
     }
 
-    if (filteredFlows.length > 0) {
-      setSelectedFlowId(filteredFlows[0].id);
+    if (hostScopedFlows.length > 0) {
+      setSelectedFlowId(hostScopedFlows[0].id);
     }
-  }, [filteredFlows, selectedFlowId, selectedView]);
+  }, [hostScopedFlows, selectedFlowId, selectedView]);
 
   const handleDeleteSelectedFlow = useCallback(async () => {
     if (selectedView !== 'traffic' || !selectedFlowId) {
@@ -333,12 +351,12 @@ function MainApp() {
     }
 
     const nextSelectedFlowId = getNextSelectedFlowIdAfterDelete(
-      filteredFlows.map((flow) => flow.id),
+      hostScopedFlows.map((flow) => flow.id),
       selectedFlowId,
     );
     removeFlow(selectedFlowId);
     setSelectedFlowId(nextSelectedFlowId);
-  }, [filteredFlows, removeFlow, selectedFlowId, selectedView, showActionError]);
+  }, [hostScopedFlows, removeFlow, selectedFlowId, selectedView, showActionError]);
 
   const handleMarkFlowForCompare = useCallback((flow: typeof flows[number]) => {
     if (!flow.response) {
@@ -501,21 +519,21 @@ function MainApp() {
         return;
       }
 
-      if (!isTypingTarget && selectedView === 'traffic' && filteredFlows.length > 0) {
+      if (!isTypingTarget && selectedView === 'traffic' && hostScopedFlows.length > 0) {
         const currentIndex = selectedFlowId
-          ? filteredFlows.findIndex((flow) => flow.id === selectedFlowId)
+          ? hostScopedFlows.findIndex((flow) => flow.id === selectedFlowId)
           : -1;
 
         if (e.key === 'ArrowDown') {
           e.preventDefault();
-          const nextIndex = Math.min(currentIndex + 1, filteredFlows.length - 1);
-          setSelectedFlowId(filteredFlows[nextIndex].id);
+          const nextIndex = Math.min(currentIndex + 1, hostScopedFlows.length - 1);
+          setSelectedFlowId(hostScopedFlows[nextIndex].id);
         }
 
         if (e.key === 'ArrowUp') {
           e.preventDefault();
           const nextIndex = currentIndex <= 0 ? 0 : currentIndex - 1;
-          setSelectedFlowId(filteredFlows[nextIndex].id);
+          setSelectedFlowId(hostScopedFlows[nextIndex].id);
         }
       }
     };
@@ -524,8 +542,8 @@ function MainApp() {
   }, [
     agentDetached,
     dismissPanels,
-    filteredFlows,
     focusTrafficFilter,
+    hostScopedFlows,
     handleClearTraffic,
     handleCompareWithMarked,
     handleCopySelectedFlowAsCurl,
@@ -563,9 +581,14 @@ function MainApp() {
               <TabBar />
               <FilterBar />
               <div className="flex flex-1 overflow-hidden">
-                <div className={`${selectedFlow ? 'w-1/2' : 'w-full'} overflow-hidden border-r border-pb-border`}>
+                <HostTree
+                  flows={filteredFlows}
+                  selectedHost={selectedHost}
+                  onSelectHost={setSelectedHost}
+                />
+                <div className={`${selectedFlow ? 'w-1/2' : 'flex-1'} overflow-hidden border-r border-pb-border`}>
                   <TrafficList
-                    flows={filteredFlows}
+                    flows={hostScopedFlows}
                     selectedId={selectedFlowId}
                     onSelect={setSelectedFlowId}
                     onEditAndResend={handleEditAndResend}
@@ -593,8 +616,6 @@ function MainApp() {
           {selectedView === 'composer' && <ComposerPanel draft={composerDraft} />}
           {selectedView === 'breakpoints' && <BreakpointEditor />}
           {selectedView === 'map-local' && <MapLocalEditor />}
-          {selectedView === 'map-remote' && <MapRemoteEditor />}
-          {selectedView === 'scripts' && <ScriptEditor selectedFlowId={selectedFlowId} />}
           {selectedView === 'map-remote' && <MapRemoteEditor />}
           {selectedView === 'scripts' && <ScriptEditor selectedFlowId={selectedFlowId} />}
           {selectedView === 'capture-rules' && <CaptureFilterEditor />}

--- a/src/renderer/components/layout/Sidebar.tsx
+++ b/src/renderer/components/layout/Sidebar.tsx
@@ -14,8 +14,6 @@ const navItems = [
   { id: 'map-local', label: 'Map Local', icon: '📁' },
   { id: 'map-remote', label: 'Map Remote', icon: '🌐' },
   { id: 'scripts', label: 'Scripts', icon: '📜' },
-  { id: 'map-remote', label: 'Map Remote', icon: '🌐' },
-  { id: 'scripts', label: 'Scripts', icon: '📜' },
   { id: 'capture-rules', label: 'Capture Rules', icon: '🛡' },
   { id: 'settings', label: 'Settings', icon: '⚙' },
 ];

--- a/src/renderer/components/rules/BreakpointPauseDialog.tsx
+++ b/src/renderer/components/rules/BreakpointPauseDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+﻿import { useEffect, useMemo, useState } from 'react';
 import type {
   BreakpointPauseMessage,
   BreakpointResumeMessage,
@@ -234,6 +234,8 @@ function BreakpointPauseDialog({
     [response?.body, response?.headers],
   );
 
+  const [requestMethod, setRequestMethod] = useState(request.method);
+  const [requestUrl, setRequestUrl] = useState(request.url);
   const [requestHeaders, setRequestHeaders] = useState<HeaderRow[]>(originalRequestHeaders);
   const [requestBody, setRequestBody] = useState<EditableBodyState>(originalRequestBody);
   const [responseHeaders, setResponseHeaders] = useState<HeaderRow[]>(originalResponseHeaders);
@@ -242,6 +244,8 @@ function BreakpointPauseDialog({
   const [statusMessage, setStatusMessage] = useState(response?.statusMessage ?? '');
 
   useEffect(() => {
+    setRequestMethod(request.method);
+    setRequestUrl(request.url);
     setRequestHeaders(originalRequestHeaders);
     setRequestBody(originalRequestBody);
     setResponseHeaders(originalResponseHeaders);
@@ -253,9 +257,30 @@ function BreakpointPauseDialog({
     originalRequestHeaders,
     originalResponseBody,
     originalResponseHeaders,
+    request.method,
+    request.url,
     response,
   ]);
 
+  const requestMethodModified = requestMethod.trim().toUpperCase() !== request.method.toUpperCase();
+  const requestUrlModified = requestUrl.trim() !== request.url;
+  const requestUrlError = useMemo(() => {
+    if (phase !== 'request') {
+      return null;
+    }
+    try {
+      const parsed = new URL(requestUrl.trim());
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return 'URL must use http:// or https://';
+      }
+      if ((parsed.protocol === 'https:' ? 'https' : 'http') !== request.protocol) {
+        return `Keep the original ${request.protocol.toUpperCase()} protocol for this paused connection.`;
+      }
+      return null;
+    } catch {
+      return 'Enter a valid absolute URL.';
+    }
+  }, [phase, request.protocol, requestUrl]);
   const requestHeadersModified = useMemo(
     () => !headersEqual(buildHeaders(requestHeaders), buildHeaders(originalRequestHeaders)),
     [originalRequestHeaders, requestHeaders],
@@ -282,6 +307,8 @@ function BreakpointPauseDialog({
   );
 
   const reset = () => {
+    setRequestMethod(request.method);
+    setRequestUrl(request.url);
     setRequestHeaders(originalRequestHeaders);
     setRequestBody(originalRequestBody);
     setResponseHeaders(originalResponseHeaders);
@@ -292,11 +319,33 @@ function BreakpointPauseDialog({
 
   const forward = () => {
     if (phase === 'request') {
+      if (requestUrlError || !requestMethod.trim()) {
+        return;
+      }
+
+      const nextHeaders = buildHeaders(requestHeaders);
+      try {
+        const parsed = new URL(requestUrl.trim());
+        if (!Object.keys(nextHeaders).some((key) => key.toLowerCase() === 'host')) {
+          nextHeaders.Host = parsed.host;
+        } else {
+          for (const key of Object.keys(nextHeaders)) {
+            if (key.toLowerCase() === 'host') {
+              nextHeaders[key] = parsed.host;
+            }
+          }
+        }
+      } catch {
+        // validated above
+      }
+
       onResume({
         flowId: flow.id,
         action: 'forward',
         request: {
-          headers: buildHeaders(requestHeaders),
+          method: requestMethod.trim().toUpperCase(),
+          url: requestUrl.trim(),
+          headers: nextHeaders,
           body: requestBody.data === '' && originalRequestBody.data === ''
             ? undefined
             : { data: requestBody.data, encoding: requestBody.encoding },
@@ -333,31 +382,59 @@ function BreakpointPauseDialog({
                 Breakpoint paused on {phase}
               </h2>
               <p className="mt-1 text-sm text-slate-400">
-                {request.method} {request.url}
+                {requestMethod || request.method} {requestUrl || request.url}
               </p>
             </div>
             <SectionBadge
               modified={phase === 'request'
-                ? requestHeadersModified || requestBodyModified
+                ? requestMethodModified || requestUrlModified || requestHeadersModified || requestBodyModified
                 : responseHeadersModified || responseBodyModified || responseStatusModified}
             />
           </div>
         </div>
 
         <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="rounded border border-slate-800 bg-slate-950/60 p-4">
-              <div className="text-xs uppercase tracking-wide text-slate-400">Method</div>
-              <div className="mt-1 text-sm text-slate-100">{request.method}</div>
-            </div>
-            <div className="rounded border border-slate-800 bg-slate-950/60 p-4">
-              <div className="text-xs uppercase tracking-wide text-slate-400">URL</div>
-              <div className="mt-1 break-all text-sm text-slate-100">{request.url}</div>
-            </div>
-          </div>
-
           {phase === 'request' ? (
             <div className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-[160px_minmax(0,1fr)]">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label className="text-xs uppercase tracking-wide text-slate-400">Method</label>
+                    <SectionBadge modified={requestMethodModified} />
+                  </div>
+                  <input
+                    className="w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-sm uppercase text-slate-100"
+                    value={requestMethod}
+                    onChange={(event) => setRequestMethod(event.target.value)}
+                    list="proxyboy-http-methods"
+                    spellCheck={false}
+                  />
+                  <datalist id="proxyboy-http-methods">
+                    {['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map((method) => (
+                      <option key={method} value={method} />
+                    ))}
+                  </datalist>
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label className="text-xs uppercase tracking-wide text-slate-400">URL</label>
+                    <SectionBadge modified={requestUrlModified} />
+                  </div>
+                  <input
+                    className="w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-sm text-slate-100"
+                    value={requestUrl}
+                    onChange={(event) => setRequestUrl(event.target.value)}
+                    spellCheck={false}
+                  />
+                  {requestUrlError ? (
+                    <p className="text-xs text-red-300">{requestUrlError}</p>
+                  ) : (
+                    <p className="text-xs text-slate-400">
+                      Edit host, path, or query. Protocol must stay {request.protocol.toUpperCase()} for this paused socket.
+                    </p>
+                  )}
+                </div>
+              </div>
               <HeaderEditor
                 label="Request headers"
                 rows={requestHeaders}
@@ -373,6 +450,16 @@ function BreakpointPauseDialog({
             </div>
           ) : response ? (
             <div className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded border border-slate-800 bg-slate-950/60 p-4">
+                  <div className="text-xs uppercase tracking-wide text-slate-400">Method</div>
+                  <div className="mt-1 text-sm text-slate-100">{request.method}</div>
+                </div>
+                <div className="rounded border border-slate-800 bg-slate-950/60 p-4">
+                  <div className="text-xs uppercase tracking-wide text-slate-400">URL</div>
+                  <div className="mt-1 break-all text-sm text-slate-100">{request.url}</div>
+                </div>
+              </div>
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <h4 className="text-sm font-semibold text-slate-100">Response status</h4>
@@ -443,7 +530,7 @@ function BreakpointPauseDialog({
               type="button"
               className="rounded bg-emerald-500 px-4 py-2 text-sm font-medium text-slate-950 hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
               onClick={forward}
-              disabled={invalidStatusCode}
+              disabled={invalidStatusCode || Boolean(requestUrlError) || (phase === 'request' && !requestMethod.trim())}
             >
               Forward
             </button>

--- a/src/renderer/components/traffic/BodyViewer.tsx
+++ b/src/renderer/components/traffic/BodyViewer.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import { parseGraphQLRequest } from '../../../shared/graphql';
 import { isProtobufContentType, type ProtobufDecodeResult, type ProtobufRawField } from '../../../shared/protobuf';
+import { isUrlEncodedForm, parseUrlEncodedForm } from '../../utils/request-parts';
 
 interface Props {
   body: string;
@@ -45,6 +46,150 @@ function renderRawFields(fields: ProtobufRawField[]): string {
   return JSON.stringify(fields, null, 2);
 }
 
+interface BodySearchProps {
+  text: string;
+  textClassName: string;
+  onCopy: () => void;
+}
+
+function BodySearchView({ text, textClassName, onCopy }: BodySearchProps) {
+  const [query, setQuery] = useState('');
+  const [currentMatch, setCurrentMatch] = useState(0);
+
+  const matchIndexes = useMemo(() => {
+    if (!query) return [] as number[];
+    const indexes: number[] = [];
+    const lowerText = text.toLowerCase();
+    const lowerQuery = query.toLowerCase();
+    let from = 0;
+    while (from <= lowerText.length - lowerQuery.length) {
+      const idx = lowerText.indexOf(lowerQuery, from);
+      if (idx === -1) break;
+      indexes.push(idx);
+      from = idx + Math.max(lowerQuery.length, 1);
+    }
+    return indexes;
+  }, [query, text]);
+
+  useEffect(() => {
+    setCurrentMatch(0);
+  }, [query, text]);
+
+  useEffect(() => {
+    if (matchIndexes.length === 0) {
+      setCurrentMatch(0);
+      return;
+    }
+    if (currentMatch >= matchIndexes.length) {
+      setCurrentMatch(0);
+    }
+  }, [currentMatch, matchIndexes]);
+
+  const goPrev = useCallback(() => {
+    if (matchIndexes.length === 0) return;
+    setCurrentMatch((prev) => (prev - 1 + matchIndexes.length) % matchIndexes.length);
+  }, [matchIndexes.length]);
+
+  const goNext = useCallback(() => {
+    if (matchIndexes.length === 0) return;
+    setCurrentMatch((prev) => (prev + 1) % matchIndexes.length);
+  }, [matchIndexes.length]);
+
+  const highlighted = useMemo(() => {
+    if (!query || matchIndexes.length === 0) {
+      return text;
+    }
+
+    const parts: React.ReactNode[] = [];
+    let lastIndex = 0;
+    const qLen = query.length;
+
+    matchIndexes.forEach((start, i) => {
+      if (start > lastIndex) {
+        parts.push(text.slice(lastIndex, start));
+      }
+      const end = start + qLen;
+      const isCurrent = i === currentMatch;
+      parts.push(
+        <mark
+          key={`${start}-${i}`}
+          id={isCurrent ? 'body-viewer-current-match' : undefined}
+          className={
+            isCurrent
+              ? 'bg-pb-accent text-white rounded-sm px-0.5'
+              : 'bg-pb-warning/40 text-pb-text rounded-sm px-0.5'
+          }
+        >
+          {text.slice(start, end)}
+        </mark>,
+      );
+      lastIndex = end;
+    });
+
+    if (lastIndex < text.length) {
+      parts.push(text.slice(lastIndex));
+    }
+
+    return parts;
+  }, [currentMatch, matchIndexes, query, text]);
+
+  useEffect(() => {
+    if (!query || matchIndexes.length === 0) return;
+    const el = document.getElementById('body-viewer-current-match');
+    el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [currentMatch, matchIndexes.length, query]);
+
+  const matchLabel = matchIndexes.length === 0
+    ? '0/0'
+    : `${currentMatch + 1}/${matchIndexes.length}`;
+
+  return (
+    <div className="bg-pb-bg rounded border border-pb-border overflow-hidden max-h-96 flex flex-col">
+      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-pb-border bg-pb-surface shrink-0">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Find in body"
+          className="h-6 flex-1 min-w-0 bg-pb-bg border border-pb-border rounded px-2 text-[11px] text-pb-text placeholder-pb-text-dim focus:outline-none focus:border-pb-accent"
+        />
+        <span className="text-[10px] text-pb-text-dim tabular-nums shrink-0 w-10 text-center">
+          {query ? matchLabel : ''}
+        </span>
+        <button
+          type="button"
+          onClick={goPrev}
+          disabled={matchIndexes.length === 0}
+          className="px-1.5 py-0.5 text-[10px] rounded bg-pb-border text-pb-text-dim hover:text-pb-text disabled:opacity-40 disabled:cursor-not-allowed"
+          title="Previous match"
+        >
+          Prev
+        </button>
+        <button
+          type="button"
+          onClick={goNext}
+          disabled={matchIndexes.length === 0}
+          className="px-1.5 py-0.5 text-[10px] rounded bg-pb-border text-pb-text-dim hover:text-pb-text disabled:opacity-40 disabled:cursor-not-allowed"
+          title="Next match"
+        >
+          Next
+        </button>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="px-2 py-0.5 text-[10px] rounded bg-pb-accent/15 text-pb-accent hover:bg-pb-accent/25 font-medium"
+          title="Copy body"
+        >
+          Copy
+        </button>
+      </div>
+      <pre className={`p-3 text-xs font-mono whitespace-pre-wrap break-all overflow-auto flex-1 ${textClassName}`}>
+        {highlighted}
+      </pre>
+    </div>
+  );
+}
+
 export default function BodyViewer({
   body,
   contentType,
@@ -55,9 +200,9 @@ export default function BodyViewer({
 }: Props) {
   const isImage = contentType.startsWith('image/');
   const [showDecoded, setShowDecoded] = useState(true);
-  const [protobufResult, setProtobufResult] = React.useState<ProtobufDecodeResult | null>(null);
-  const [protobufError, setProtobufError] = React.useState<string | null>(null);
-  const [protobufLoading, setProtobufLoading] = React.useState(false);
+  const [protobufResult, setProtobufResult] = useState<ProtobufDecodeResult | null>(null);
+  const [protobufError, setProtobufError] = useState<string | null>(null);
+  const [protobufLoading, setProtobufLoading] = useState(false);
   const shouldAttemptProtobuf = !isImage && showDecoded && isProtobufContentType(contentType);
 
   // For base64 non-image bodies, attempt to decode/decompress
@@ -72,7 +217,13 @@ export default function BodyViewer({
     return parseGraphQLRequest(displayBody, contentType);
   }, [contentType, detectGraphQL, displayBody, isBase64, isImage]);
 
-  React.useEffect(() => {
+  const formFields = useMemo(() => {
+    if (isImage || isBase64 || graphqlRequest) return null;
+    if (!isUrlEncodedForm(contentType)) return null;
+    return parseUrlEncodedForm(displayBody);
+  }, [contentType, displayBody, graphqlRequest, isBase64, isImage]);
+
+  useEffect(() => {
     let cancelled = false;
 
     if (!shouldAttemptProtobuf) {
@@ -127,6 +278,10 @@ export default function BodyViewer({
     }
     return displayBody;
   }, [displayBody, contentType, isImage]);
+
+  const handleCopyFormatted = useCallback(() => {
+    void navigator.clipboard.writeText(formatted);
+  }, [formatted]);
 
   if (isImage && isBase64) {
     const dataUrl = `data:${contentType};base64,${body}`;
@@ -252,14 +407,61 @@ export default function BodyViewer({
     );
   }
 
+  if (formFields) {
+    const formText = formFields.map((f) => `${f.key}=${f.value}`).join('\n');
+    return (
+      <div className="bg-pb-bg rounded border border-pb-border overflow-hidden max-h-96 flex flex-col">
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-pb-border bg-pb-surface shrink-0">
+          <span className="rounded bg-pb-accent/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-pb-accent">
+            Form
+          </span>
+          <span className="text-[10px] text-pb-text-dim">{formFields.length} field{formFields.length === 1 ? '' : 's'}</span>
+          <button
+            type="button"
+            onClick={() => void navigator.clipboard.writeText(formText)}
+            className="ml-auto px-2 py-0.5 text-[10px] rounded bg-pb-accent/15 text-pb-accent hover:bg-pb-accent/25 font-medium"
+            title="Copy form fields"
+          >
+            Copy
+          </button>
+        </div>
+        <div className="overflow-auto flex-1">
+          <table className="w-full text-xs">
+            <thead className="sticky top-0 bg-pb-surface border-b border-pb-border">
+              <tr className="text-left text-[10px] uppercase tracking-wide text-pb-text-dim">
+                <th className="px-3 py-1.5 font-semibold w-1/3">Name</th>
+                <th className="px-3 py-1.5 font-semibold">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {formFields.length === 0 ? (
+                <tr>
+                  <td colSpan={2} className="px-3 py-3 text-pb-text-dim">No form fields</td>
+                </tr>
+              ) : (
+                formFields.map((field, index) => (
+                  <tr key={`${field.key}-${index}`} className="border-b border-pb-border/40 align-top">
+                    <td className="px-3 py-1.5 font-mono text-pb-info break-all">{field.key}</td>
+                    <td className="px-3 py-1.5 font-mono text-pb-text break-all whitespace-pre-wrap">{field.value}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+
   const isJson = contentType.includes('json');
   const isHtml = contentType.includes('html');
   const isXml = contentType.includes('xml');
+  const textClassName = isJson ? 'text-pb-info' : isHtml || isXml ? 'text-pb-warning' : 'text-pb-text';
 
   return (
-    <div className="bg-pb-bg rounded border border-pb-border overflow-auto max-h-96">
+    <div className="space-y-0">
       {isBase64 && !isImage && (
-        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-pb-border bg-pb-surface">
+        <div className="flex items-center gap-2 px-3 py-1.5 border border-b-0 border-pb-border bg-pb-surface rounded-t">
           <span className="text-[10px] text-pb-text-dim">
             {decoded ? '✓ Decoded' : '⚠ Binary'}
           </span>
@@ -276,11 +478,11 @@ export default function BodyViewer({
           {protobufLoading && <span className="text-[10px] text-pb-text-dim">Protobuf…</span>}
         </div>
       )}
-      <pre className={`p-3 text-xs font-mono whitespace-pre-wrap break-all
-        ${isJson ? 'text-pb-info' : isHtml || isXml ? 'text-pb-warning' : 'text-pb-text'}`}
-      >
-        {formatted}
-      </pre>
+      <BodySearchView
+        text={formatted}
+        textClassName={textClassName}
+        onCopy={handleCopyFormatted}
+      />
     </div>
   );
 }

--- a/src/renderer/components/traffic/HostTree.tsx
+++ b/src/renderer/components/traffic/HostTree.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo } from 'react';
+import type { HttpFlow } from '../../../shared/types';
+
+interface HostCount {
+  host: string;
+  count: number;
+  errorCount: number;
+}
+
+interface Props {
+  flows: HttpFlow[];
+  selectedHost: string | null;
+  onSelectHost: (host: string | null) => void;
+}
+
+function getHostCounts(flows: HttpFlow[]): HostCount[] {
+  const counts = new Map<string, HostCount>();
+  for (const flow of flows) {
+    const host = flow.request.host || '(unknown)';
+    const current = counts.get(host) ?? { host, count: 0, errorCount: 0 };
+    current.count += 1;
+    if (flow.state === 'error' || (flow.response && flow.response.statusCode >= 400)) {
+      current.errorCount += 1;
+    }
+    counts.set(host, current);
+  }
+
+  return Array.from(counts.values()).sort((left, right) => {
+    if (right.count !== left.count) {
+      return right.count - left.count;
+    }
+    return left.host.localeCompare(right.host);
+  });
+}
+
+export default function HostTree({ flows, selectedHost, onSelectHost }: Props) {
+  const hosts = useMemo(() => getHostCounts(flows), [flows]);
+
+  return (
+    <div className="flex h-full w-52 shrink-0 flex-col border-r border-pb-border bg-pb-surface">
+      <div className="flex items-center justify-between border-b border-pb-border px-3 py-2">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-pb-text-dim">
+          Hosts
+        </div>
+        <div className="text-[10px] text-pb-text-dim">{hosts.length}</div>
+      </div>
+      <div className="flex-1 overflow-y-auto py-1">
+        <button
+          type="button"
+          onClick={() => onSelectHost(null)}
+          className={`flex w-full items-center justify-between px-3 py-1.5 text-left text-xs transition-colors ${
+            selectedHost == null
+              ? 'bg-pb-accent/15 text-pb-accent'
+              : 'text-pb-text hover:bg-pb-surface-hover'
+          }`}
+        >
+          <span>All hosts</span>
+          <span className="font-mono text-[10px] text-pb-text-dim">{flows.length}</span>
+        </button>
+        {hosts.map((entry) => (
+          <button
+            key={entry.host}
+            type="button"
+            onClick={() => onSelectHost(entry.host === selectedHost ? null : entry.host)}
+            className={`flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-xs transition-colors ${
+              selectedHost === entry.host
+                ? 'bg-pb-accent/15 text-pb-accent'
+                : 'text-pb-text hover:bg-pb-surface-hover'
+            }`}
+            title={entry.host}
+          >
+            <span className="truncate font-mono">{entry.host}</span>
+            <span className="flex shrink-0 items-center gap-1 font-mono text-[10px]">
+              {entry.errorCount > 0 && (
+                <span className="text-pb-error">{entry.errorCount}</span>
+              )}
+              <span className="text-pb-text-dim">{entry.count}</span>
+            </span>
+          </button>
+        ))}
+        {hosts.length === 0 && (
+          <div className="px-3 py-4 text-xs text-pb-text-dim">
+            Hosts appear here once traffic is captured.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/traffic/RequestView.tsx
+++ b/src/renderer/components/traffic/RequestView.tsx
@@ -1,21 +1,44 @@
-import React from 'react';
+﻿import React, { useMemo, useState } from 'react';
 import BodyViewer from './BodyViewer';
 import type { HttpRequest } from '../../../shared/types';
+import { parseQueryParams } from '../../utils/request-parts';
 
 interface Props {
   request: HttpRequest;
 }
 
 export default function RequestView({ request }: Props) {
+  const [headerFilter, setHeaderFilter] = useState('');
+  const queryParams = useMemo(() => parseQueryParams(request.url), [request.url]);
+  const headers = useMemo(() => {
+    const entries = Object.entries(request.headers);
+    const needle = headerFilter.trim().toLowerCase();
+    if (!needle) {
+      return entries;
+    }
+    return entries.filter(([key, value]) => {
+      const haystack = `${key} ${Array.isArray(value) ? value.join(' ') : value}`.toLowerCase();
+      return haystack.includes(needle);
+    });
+  }, [headerFilter, request.headers]);
+
   return (
     <div className="space-y-4">
-      {/* General */}
       <section>
-        <h3 className="text-xs font-semibold text-pb-text-dim uppercase mb-2">General</h3>
-        <div className="bg-pb-surface rounded p-3 space-y-1 text-xs">
-          <div><span className="text-pb-text-dim">URL: </span><span className="font-mono">{request.url}</span></div>
-          <div><span className="text-pb-text-dim">Method: </span><span className="font-mono">{request.method}</span></div>
-          <div><span className="text-pb-text-dim">Protocol: </span><span className="font-mono">{request.protocol.toUpperCase()}</span></div>
+        <h3 className="mb-2 text-xs font-semibold uppercase text-pb-text-dim">General</h3>
+        <div className="space-y-1 rounded bg-pb-surface p-3 text-xs">
+          <div>
+            <span className="text-pb-text-dim">URL: </span>
+            <span className="font-mono break-all">{request.url}</span>
+          </div>
+          <div>
+            <span className="text-pb-text-dim">Method: </span>
+            <span className="font-mono">{request.method}</span>
+          </div>
+          <div>
+            <span className="text-pb-text-dim">Protocol: </span>
+            <span className="font-mono">{request.protocol.toUpperCase()}</span>
+          </div>
           {request.graphqlOperationType && (
             <div>
               <span className="text-pb-text-dim">GraphQL: </span>
@@ -29,25 +52,62 @@ export default function RequestView({ request }: Props) {
         </div>
       </section>
 
-      {/* Headers */}
+      {queryParams.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase text-pb-text-dim">
+            Query Params ({queryParams.length})
+          </h3>
+          <div className="overflow-hidden rounded border border-pb-border bg-pb-surface">
+            <table className="w-full text-xs">
+              <thead className="bg-pb-bg text-pb-text-dim">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">Name</th>
+                  <th className="px-3 py-2 text-left font-medium">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {queryParams.map((param, index) => (
+                  <tr key={`${param.key}-${index}`} className="border-t border-pb-border">
+                    <td className="px-3 py-2 align-top font-mono text-pb-accent">{param.key}</td>
+                    <td className="px-3 py-2 align-top break-all font-mono text-pb-text">{param.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
       <section>
-        <h3 className="text-xs font-semibold text-pb-text-dim uppercase mb-2">
-          Headers ({Object.keys(request.headers).length})
-        </h3>
-        <div className="bg-pb-surface rounded p-3 space-y-1 text-xs font-mono">
-          {Object.entries(request.headers).map(([key, value]) => (
-            <div key={key} className="flex gap-2">
-              <span className="text-pb-accent whitespace-nowrap">{key}:</span>
-              <span className="text-pb-text break-all">{String(value)}</span>
-            </div>
-          ))}
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <h3 className="text-xs font-semibold uppercase text-pb-text-dim">
+            Headers ({Object.keys(request.headers).length})
+          </h3>
+          <input
+            type="text"
+            value={headerFilter}
+            onChange={(event) => setHeaderFilter(event.target.value)}
+            placeholder="Filter headers"
+            className="h-7 w-44 rounded border border-pb-border bg-pb-bg px-2 text-xs text-pb-text placeholder-pb-text-dim focus:border-pb-accent focus:outline-none"
+          />
+        </div>
+        <div className="space-y-1 rounded bg-pb-surface p-3 font-mono text-xs">
+          {headers.length === 0 ? (
+            <div className="text-pb-text-dim">No headers match this filter.</div>
+          ) : (
+            headers.map(([key, value]) => (
+              <div key={key} className="flex gap-2">
+                <span className="whitespace-nowrap text-pb-accent">{key}:</span>
+                <span className="break-all text-pb-text">{String(value)}</span>
+              </div>
+            ))
+          )}
         </div>
       </section>
 
-      {/* Body */}
       {request.body && (
         <section>
-          <h3 className="text-xs font-semibold text-pb-text-dim uppercase mb-2">
+          <h3 className="mb-2 text-xs font-semibold uppercase text-pb-text-dim">
             Body ({request.bodySize} bytes)
           </h3>
           <BodyViewer

--- a/src/renderer/components/traffic/ResponseView.tsx
+++ b/src/renderer/components/traffic/ResponseView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React, { useMemo, useState } from 'react';
 import BodyViewer from './BodyViewer';
 import type { HttpResponse } from '../../../shared/types';
 
@@ -8,40 +8,62 @@ interface Props {
 }
 
 export default function ResponseView({ response, requestPath }: Props) {
+  const [headerFilter, setHeaderFilter] = useState('');
   const statusColor = response.statusCode < 300 ? 'text-pb-success' :
                       response.statusCode < 400 ? 'text-pb-warning' : 'text-pb-error';
+  const headers = useMemo(() => {
+    const entries = Object.entries(response.headers);
+    const needle = headerFilter.trim().toLowerCase();
+    if (!needle) {
+      return entries;
+    }
+    return entries.filter(([key, value]) => {
+      const haystack = `${key} ${Array.isArray(value) ? value.join(' ') : value}`.toLowerCase();
+      return haystack.includes(needle);
+    });
+  }, [headerFilter, response.headers]);
 
   return (
     <div className="space-y-4">
-      {/* Status */}
       <section>
-        <h3 className="text-xs font-semibold text-pb-text-dim uppercase mb-2">Status</h3>
-        <div className="bg-pb-surface rounded p-3 text-xs">
+        <h3 className="mb-2 text-xs font-semibold uppercase text-pb-text-dim">Status</h3>
+        <div className="rounded bg-pb-surface p-3 text-xs">
           <span className={`font-mono font-bold ${statusColor}`}>{response.statusCode}</span>
-          <span className="text-pb-text-dim ml-2">{response.statusMessage}</span>
-          <span className="text-pb-text-dim ml-4">({response.duration}ms)</span>
+          <span className="ml-2 text-pb-text-dim">{response.statusMessage}</span>
+          <span className="ml-4 text-pb-text-dim">({response.duration}ms)</span>
         </div>
       </section>
 
-      {/* Headers */}
       <section>
-        <h3 className="text-xs font-semibold text-pb-text-dim uppercase mb-2">
-          Headers ({Object.keys(response.headers).length})
-        </h3>
-        <div className="bg-pb-surface rounded p-3 space-y-1 text-xs font-mono">
-          {Object.entries(response.headers).map(([key, value]) => (
-            <div key={key} className="flex gap-2">
-              <span className="text-pb-accent whitespace-nowrap">{key}:</span>
-              <span className="text-pb-text break-all">{String(value)}</span>
-            </div>
-          ))}
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <h3 className="text-xs font-semibold uppercase text-pb-text-dim">
+            Headers ({Object.keys(response.headers).length})
+          </h3>
+          <input
+            type="text"
+            value={headerFilter}
+            onChange={(event) => setHeaderFilter(event.target.value)}
+            placeholder="Filter headers"
+            className="h-7 w-44 rounded border border-pb-border bg-pb-bg px-2 text-xs text-pb-text placeholder-pb-text-dim focus:border-pb-accent focus:outline-none"
+          />
+        </div>
+        <div className="space-y-1 rounded bg-pb-surface p-3 font-mono text-xs">
+          {headers.length === 0 ? (
+            <div className="text-pb-text-dim">No headers match this filter.</div>
+          ) : (
+            headers.map(([key, value]) => (
+              <div key={key} className="flex gap-2">
+                <span className="whitespace-nowrap text-pb-accent">{key}:</span>
+                <span className="break-all text-pb-text">{String(value)}</span>
+              </div>
+            ))
+          )}
         </div>
       </section>
 
-      {/* Body */}
       {response.body && (
         <section>
-          <h3 className="text-xs font-semibold text-pb-text-dim uppercase mb-2">
+          <h3 className="mb-2 text-xs font-semibold uppercase text-pb-text-dim">
             Body ({response.bodySize} bytes)
           </h3>
           <BodyViewer

--- a/src/renderer/components/traffic/TrafficList.tsx
+++ b/src/renderer/components/traffic/TrafficList.tsx
@@ -4,8 +4,11 @@ import TrafficRow from './TrafficRow';
 import ContextMenu from './ContextMenu';
 import type { ContextMenuItem } from './ContextMenu';
 import { flowToCurl } from '../../utils/curl';
+import { flowToFetch, flowToPowerShell } from '../../utils/export-formats';
+import { deleteTrafficFlow } from '../../utils/app-actions';
 import { useAppStore } from '../../stores/app';
 import { useRulesStore } from '../../stores/rules';
+import { useTrafficStore } from '../../stores/traffic';
 import type { HttpFlow, HttpHeaders } from '../../../shared/types';
 
 export type ColumnKey = 'timestamp' | 'method' | 'status' | 'graphql' | 'url' | 'host' | 'type' | 'size' | 'time';
@@ -77,6 +80,36 @@ function getQuickAddRulePattern(flow: HttpFlow): { hostLabel: string; urlPattern
     };
   } catch {
     return null;
+  }
+}
+
+function getExactUrlPattern(flow: HttpFlow): { label: string; urlPattern: string } | null {
+  const url = flow.request.url;
+  if (!url) return null;
+  return {
+    label: url.length > 60 ? `${url.slice(0, 57)}...` : url,
+    urlPattern: `^${escapeRegex(url)}$`,
+  };
+}
+
+function getMapRemoteHostPattern(flow: HttpFlow): { hostLabel: string; urlPattern: string; origin: string } | null {
+  try {
+    const parsedUrl = new URL(flow.request.url);
+    const hostLabel = parsedUrl.hostname || flow.request.host;
+    if (!hostLabel) return null;
+    return {
+      hostLabel,
+      origin: parsedUrl.origin,
+      urlPattern: `*://${hostLabel}/*`,
+    };
+  } catch {
+    const hostLabel = flow.request.host;
+    if (!hostLabel) return null;
+    return {
+      hostLabel,
+      origin: `https://${hostLabel}`,
+      urlPattern: `*://${hostLabel}/*`,
+    };
   }
 }
 
@@ -159,10 +192,13 @@ export default function TrafficList({
   onClearComparison,
 }: Props) {
   const trafficRowColorMode = useAppStore((state) => state.trafficRowColorMode);
+  const removeFlow = useTrafficStore((state) => state.removeFlow);
   const [sort, setSort] = useState<SortState>({ column: null, direction: 'asc' });
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [visibleColumns, setVisibleColumns] = useState<Set<ColumnKey>>(loadVisibleColumns);
   const [showColumnPicker, setShowColumnPicker] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [anchorId, setAnchorId] = useState<string | null>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
 
   // Close column picker on outside click
@@ -176,6 +212,31 @@ export default function TrafficList({
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, [showColumnPicker]);
+
+  // Drop multi-select ids that are no longer in the list
+  useEffect(() => {
+    const flowIdSet = new Set(flows.map((flow) => flow.id));
+    setSelectedIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (flowIdSet.has(id)) next.add(id);
+        else changed = true;
+      });
+      return changed ? next : prev;
+    });
+  }, [flows]);
+
+  // Keep multi-select in sync with external single selection
+  useEffect(() => {
+    if (!selectedId) return;
+    setSelectedIds((prev) => {
+      if (prev.size <= 1 && prev.has(selectedId)) return prev;
+      if (prev.size > 1 && prev.has(selectedId)) return prev;
+      return new Set([selectedId]);
+    });
+    setAnchorId(selectedId);
+  }, [selectedId]);
 
   const toggleColumn = useCallback((key: ColumnKey) => {
     setVisibleColumns(prev => {
@@ -209,10 +270,70 @@ export default function TrafficList({
 
   const sortedFlows = useMemo(() => sortFlows(flows, sort), [flows, sort]);
 
+  const handleRowSelect = useCallback((id: string, e?: React.MouseEvent) => {
+    const isToggle = Boolean(e && (e.metaKey || e.ctrlKey));
+    const isRange = Boolean(e && e.shiftKey);
+
+    if (isRange && anchorId) {
+      const ids = sortedFlows.map((flow) => flow.id);
+      const start = ids.indexOf(anchorId);
+      const end = ids.indexOf(id);
+      if (start !== -1 && end !== -1) {
+        const [from, to] = start < end ? [start, end] : [end, start];
+        const rangeIds = ids.slice(from, to + 1);
+        setSelectedIds(new Set(rangeIds));
+        onSelect(id);
+        return;
+      }
+    }
+
+    if (isToggle) {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        if (selectedId) next.add(selectedId);
+        return next;
+      });
+      setAnchorId(id);
+      onSelect(id);
+      return;
+    }
+
+    setSelectedIds(new Set([id]));
+    setAnchorId(id);
+    onSelect(id);
+  }, [anchorId, onSelect, selectedId, sortedFlows]);
+
   const handleContextMenu = useCallback((e: React.MouseEvent, flow: HttpFlow) => {
     e.preventDefault();
+    setSelectedIds((prev) => {
+      if (prev.has(flow.id)) return prev;
+      return new Set([flow.id]);
+    });
+    onSelect(flow.id);
     setContextMenu({ x: e.clientX, y: e.clientY, flow });
-  }, []);
+  }, [onSelect]);
+
+  const handleBulkDelete = useCallback(async () => {
+    const ids = [...selectedIds];
+    if (ids.length === 0) return;
+
+    const failures: string[] = [];
+    for (const id of ids) {
+      const result = await deleteTrafficFlow(window.proxyboy, id);
+      if (result.success) {
+        removeFlow(id);
+      } else {
+        failures.push(result.error || id);
+      }
+    }
+
+    setSelectedIds(new Set());
+    if (failures.length > 0) {
+      window.alert(`Removed ${ids.length - failures.length} request(s). ${failures.length} could not be deleted (only completed requests can be removed).`);
+    }
+  }, [removeFlow, selectedIds]);
 
   const quickAddCaptureRule = useCallback(async (flow: HttpFlow, type: 'allow-list' | 'block-list') => {
     const api = (window as any).proxyboy;
@@ -265,7 +386,99 @@ export default function TrafficList({
     );
   }, []);
 
+  const createBreakpointForUrl = useCallback(async (flow: HttpFlow) => {
+    const api = (window as any).proxyboy;
+    if (!api?.rules) {
+      window.alert('Rule controls are unavailable.');
+      return;
+    }
+
+    const pattern = getExactUrlPattern(flow);
+    if (!pattern) {
+      window.alert('Could not derive a URL pattern from this request.');
+      return;
+    }
+
+    await api.rules.create({
+      type: 'breakpoint',
+      name: `Breakpoint ${pattern.label}`,
+      enabled: true,
+      matchCriteria: {
+        urlPattern: pattern.urlPattern,
+        isRegex: true,
+      },
+      breakOn: 'both',
+    });
+    await useRulesStore.getState().loadRules();
+    window.alert('Created a breakpoint rule for this URL.');
+  }, []);
+
+  const createMapRemoteForHost = useCallback(async (flow: HttpFlow) => {
+    const api = (window as any).proxyboy;
+    if (!api?.rules) {
+      window.alert('Rule controls are unavailable.');
+      return;
+    }
+
+    const pattern = getMapRemoteHostPattern(flow);
+    if (!pattern) {
+      window.alert('Could not derive a host pattern from this request.');
+      return;
+    }
+
+    const destination = window.prompt(
+      `Destination base URL for ${pattern.hostLabel} (path will be preserved):`,
+      pattern.origin,
+    );
+    if (!destination) return;
+
+    const normalizedDestination = destination.trim();
+    try {
+      const parsed = new URL(normalizedDestination);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        window.alert('Destination URL must start with http:// or https://.');
+        return;
+      }
+    } catch {
+      window.alert('Enter a valid destination URL.');
+      return;
+    }
+
+    await api.rules.create({
+      type: 'map-remote',
+      name: `Map ${pattern.hostLabel}`,
+      enabled: true,
+      matchCriteria: {
+        urlPattern: pattern.urlPattern,
+        isRegex: false,
+      },
+      destinationUrl: normalizedDestination,
+      preservePath: true,
+    });
+    await useRulesStore.getState().loadRules();
+    window.alert(`Created a Map Remote rule for ${pattern.hostLabel}.`);
+  }, []);
+
   const buildMenuItems = useCallback((flow: HttpFlow): ContextMenuItem[] => {
+    if (selectedIds.size > 1 && selectedIds.has(flow.id)) {
+      const selectedFlows = sortedFlows.filter((item) => selectedIds.has(item.id));
+      return [
+        {
+          label: `Copy URLs (${selectedIds.size})`,
+          icon: '🔗',
+          onClick: () => {
+            const urls = selectedFlows.map((item) => item.request.url).join('\n');
+            void navigator.clipboard.writeText(urls);
+          },
+        },
+        {
+          label: `Delete selected (${selectedIds.size})`,
+          icon: '🗑',
+          onClick: () => { void handleBulkDelete(); },
+        },
+      ];
+    }
+
     const compareItems: ContextMenuItem[] = [];
 
     if (flow.response) {
@@ -305,6 +518,16 @@ export default function TrafficList({
         onClick: () => quickAddCaptureRule(flow, 'allow-list'),
       },
       {
+        label: 'Create breakpoint for this URL',
+        icon: '⏸',
+        onClick: () => { void createBreakpointForUrl(flow); },
+      },
+      {
+        label: 'Create Map Remote for this host',
+        icon: '🌐',
+        onClick: () => { void createMapRemoteForHost(flow); },
+      },
+      {
         label: 'Edit and Resend',
         icon: '✍️',
         onClick: () => onEditAndResend(flow),
@@ -323,6 +546,16 @@ export default function TrafficList({
         label: 'Copy as cURL',
         icon: '⌘',
         onClick: () => navigator.clipboard.writeText(flowToCurl(flow)),
+      },
+      {
+        label: 'Copy as Fetch',
+        icon: 'ƒ',
+        onClick: () => navigator.clipboard.writeText(flowToFetch(flow)),
+      },
+      {
+        label: 'Copy as PowerShell',
+        icon: '>_',
+        onClick: () => navigator.clipboard.writeText(flowToPowerShell(flow)),
       },
       {
         label: 'Copy URL',
@@ -353,14 +586,37 @@ export default function TrafficList({
         },
       },
     ];
-  }, [compareTargetFlowId, markedFlowId, onClearComparison, onCompareWithMarked, onEditAndResend, onMarkForCompare, quickAddCaptureRule]);
+  }, [
+    compareTargetFlowId,
+    createBreakpointForUrl,
+    createMapRemoteForHost,
+    handleBulkDelete,
+    markedFlowId,
+    onClearComparison,
+    onCompareWithMarked,
+    onEditAndResend,
+    onMarkForCompare,
+    quickAddCaptureRule,
+    selectedIds,
+    sortedFlows,
+  ]);
 
   if (flows.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-pb-text-dim">
+      <div className="flex flex-col items-center justify-center h-full text-pb-text-dim px-6 text-center">
         <div className="text-4xl mb-4">📡</div>
-        <div className="text-lg font-medium">No traffic captured</div>
+        <div className="text-lg font-medium text-pb-text">No traffic captured</div>
         <div className="text-sm mt-1">Start the proxy and make some requests</div>
+        <div className="mt-4 max-w-md space-y-2 text-xs leading-relaxed">
+          <div className="rounded border border-pb-border bg-pb-surface px-3 py-2">
+            <span className="font-semibold text-pb-text">Proxy tip:</span>{' '}
+            Enable system proxy, or point clients to <span className="font-mono text-pb-info">127.0.0.1:9090</span>.
+          </div>
+          <div className="rounded border border-pb-border bg-pb-surface px-3 py-2">
+            <span className="font-semibold text-pb-text">Certificate tip:</span>{' '}
+            For HTTPS interception open <span className="text-pb-text">Settings → Install Certificate</span>.
+          </div>
+        </div>
       </div>
     );
   }
@@ -414,6 +670,25 @@ export default function TrafficList({
           )}
         </div>
       </div>
+      {selectedIds.size > 1 && (
+        <div className="flex items-center gap-3 h-8 px-3 bg-pb-accent/10 border-b border-pb-border text-xs text-pb-text">
+          <span className="font-medium">{selectedIds.size} selected</span>
+          <button
+            type="button"
+            onClick={() => { void handleBulkDelete(); }}
+            className="px-2 py-0.5 rounded bg-pb-error/15 text-pb-error hover:bg-pb-error/25 font-medium"
+          >
+            Bulk delete
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelectedIds(new Set())}
+            className="px-2 py-0.5 rounded text-pb-text-dim hover:text-pb-text"
+          >
+            Clear
+          </button>
+        </div>
+      )}
       {/* Rows */}
       <Virtuoso
         data={sortedFlows}
@@ -421,8 +696,8 @@ export default function TrafficList({
           <TrafficRow
             key={flow.id}
             flow={flow}
-            selected={flow.id === selectedId}
-            onSelect={onSelect}
+            selected={flow.id === selectedId || selectedIds.has(flow.id)}
+            onSelect={handleRowSelect}
             onContextMenu={handleContextMenu}
             visibleColumns={visibleColumns}
             colorMode={trafficRowColorMode}

--- a/src/renderer/components/traffic/TrafficList.tsx
+++ b/src/renderer/components/traffic/TrafficList.tsx
@@ -227,15 +227,14 @@ export default function TrafficList({
     });
   }, [flows]);
 
-  // Keep multi-select in sync with external single selection
+  // Keep multi-select in sync with external single selection (e.g. keyboard nav)
   useEffect(() => {
     if (!selectedId) return;
     setSelectedIds((prev) => {
-      if (prev.size <= 1 && prev.has(selectedId)) return prev;
-      if (prev.size > 1 && prev.has(selectedId)) return prev;
+      if (prev.has(selectedId)) return prev;
       return new Set([selectedId]);
     });
-    setAnchorId(selectedId);
+    setAnchorId((prev) => prev ?? selectedId);
   }, [selectedId]);
 
   const toggleColumn = useCallback((key: ColumnKey) => {

--- a/src/renderer/components/traffic/TrafficRow.tsx
+++ b/src/renderer/components/traffic/TrafficRow.tsx
@@ -6,7 +6,7 @@ import { getTrafficRowAccentColor, type TrafficRowColorMode } from '../../utils/
 interface Props {
   flow: HttpFlow;
   selected: boolean;
-  onSelect: (id: string) => void;
+  onSelect: (id: string, e?: React.MouseEvent) => void;
   onContextMenu?: (e: React.MouseEvent, flow: HttpFlow) => void;
   visibleColumns: Set<ColumnKey>;
   colorMode: TrafficRowColorMode;
@@ -94,7 +94,7 @@ function TrafficRowInner({
 
   return (
     <div
-      onClick={() => onSelect(flow.id)}
+      onClick={(e) => onSelect(flow.id, e)}
       onContextMenu={(e) => onContextMenu?.(e, flow)}
       className={`flex items-center h-8 px-3 text-xs cursor-pointer border-b border-l-[3px] border-pb-border/30 transition-colors
         ${selected ? 'bg-pb-accent/15 text-pb-text' : 'hover:bg-pb-surface-hover text-pb-text'}`}

--- a/src/renderer/utils/export-formats.test.ts
+++ b/src/renderer/utils/export-formats.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { HttpFlow } from '../../shared/types';
+import { flowToFetch, flowToPowerShell } from './export-formats';
+
+function createFlow(): HttpFlow {
+  return {
+    id: 'flow-1',
+    state: 'complete',
+    tags: [],
+    createdAt: 1,
+    request: {
+      id: 'req-1',
+      method: 'POST',
+      url: 'https://api.example.com/v1/items?active=true',
+      protocol: 'https',
+      host: 'api.example.com',
+      path: '/v1/items?active=true',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer token',
+        host: 'api.example.com',
+      },
+      body: '{"name":"ProxyBoy"}',
+      bodySize: 20,
+      timestamp: 1,
+    },
+  };
+}
+
+describe('export formats', () => {
+  it('builds a fetch snippet', () => {
+    const snippet = flowToFetch(createFlow());
+    expect(snippet).toContain('fetch("https://api.example.com/v1/items?active=true"');
+    expect(snippet).toContain('method: "POST"');
+    expect(snippet).toContain('"authorization": "Bearer token"');
+    expect(snippet).toContain('body: "{\\"name\\":\\"ProxyBoy\\"}"');
+    expect(snippet).not.toContain('"host"');
+  });
+
+  it('builds a PowerShell snippet', () => {
+    const snippet = flowToPowerShell(createFlow());
+    expect(snippet).toContain("$uri = 'https://api.example.com/v1/items?active=true'");
+    expect(snippet).toContain("$method = 'POST'");
+    expect(snippet).toContain("Invoke-RestMethod -Uri $uri -Method $method -Headers $headers -Body $body");
+    expect(snippet).toContain("'authorization' = 'Bearer token'");
+  });
+});

--- a/src/renderer/utils/export-formats.ts
+++ b/src/renderer/utils/export-formats.ts
@@ -1,0 +1,96 @@
+import type { HttpFlow, HttpHeaders } from '../../shared/types';
+
+function headerValue(value: string | string[]): string {
+  return Array.isArray(value) ? value.join(', ') : value;
+}
+
+function jsString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function powershellSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function getBodyText(flow: HttpFlow): string | null {
+  const body = flow.request.body;
+  if (body == null) {
+    return null;
+  }
+  if (typeof body === 'string') {
+    return body;
+  }
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(body)) {
+    return body.toString('utf8');
+  }
+  return String(body);
+}
+
+function shouldSkipHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower === 'host' || lower === 'content-length' || lower === 'connection';
+}
+
+export function flowToFetch(flow: HttpFlow): string {
+  const { request } = flow;
+  const headers = Object.entries(request.headers)
+    .filter(([name]) => !shouldSkipHeader(name))
+    .map(([name, value]) => `    ${jsString(name)}: ${jsString(headerValue(value))}`)
+    .join(',\n');
+
+  const bodyText = getBodyText(flow);
+  const lines = [
+    'fetch(' + jsString(request.url) + ', {',
+    `  method: ${jsString(request.method)},`,
+  ];
+
+  if (headers) {
+    lines.push('  headers: {');
+    lines.push(headers);
+    lines.push('  },');
+  }
+
+  if (bodyText != null && request.method.toUpperCase() !== 'GET' && request.method.toUpperCase() !== 'HEAD') {
+    lines.push(`  body: ${jsString(bodyText)},`);
+  }
+
+  lines.push('});');
+  return lines.join('\n');
+}
+
+export function flowToPowerShell(flow: HttpFlow): string {
+  const { request } = flow;
+  const headers = Object.entries(request.headers)
+    .filter(([name]) => !shouldSkipHeader(name))
+    .map(([name, value]) => `  ${powershellSingleQuoted(name)} = ${powershellSingleQuoted(headerValue(value))}`)
+    .join('\n');
+
+  const bodyText = getBodyText(flow);
+  const lines = [
+    `$uri = ${powershellSingleQuoted(request.url)}`,
+    `$method = ${powershellSingleQuoted(request.method)}`,
+  ];
+
+  if (headers) {
+    lines.push('$headers = @{');
+    lines.push(headers);
+    lines.push('}');
+  } else {
+    lines.push('$headers = @{}');
+  }
+
+  if (bodyText != null && request.method.toUpperCase() !== 'GET' && request.method.toUpperCase() !== 'HEAD') {
+    lines.push(`$body = ${powershellSingleQuoted(bodyText)}`);
+    lines.push('Invoke-RestMethod -Uri $uri -Method $method -Headers $headers -Body $body');
+  } else {
+    lines.push('Invoke-RestMethod -Uri $uri -Method $method -Headers $headers');
+  }
+
+  return lines.join('\n');
+}
+
+export function formatHeaders(headers: HttpHeaders): string {
+  return Object.entries(headers)
+    .map(([name, value]) => `${name}: ${headerValue(value)}`)
+    .join('\n');
+}

--- a/src/renderer/utils/request-parts.test.ts
+++ b/src/renderer/utils/request-parts.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { isUrlEncodedForm, parseQueryParams, parseUrlEncodedForm } from './request-parts';
+
+describe('request-parts', () => {
+  it('parses query params from a full URL', () => {
+    expect(parseQueryParams('https://example.com/search?q=proxy+boy&page=2')).toEqual([
+      { key: 'q', value: 'proxy boy' },
+      { key: 'page', value: '2' },
+    ]);
+  });
+
+  it('parses urlencoded form bodies', () => {
+    expect(parseUrlEncodedForm('name=ProxyBoy&token=a%2Bb')).toEqual([
+      { key: 'name', value: 'ProxyBoy' },
+      { key: 'token', value: 'a+b' },
+    ]);
+  });
+
+  it('detects urlencoded content types', () => {
+    expect(isUrlEncodedForm('application/x-www-form-urlencoded; charset=UTF-8')).toBe(true);
+    expect(isUrlEncodedForm('application/json')).toBe(false);
+  });
+});

--- a/src/renderer/utils/request-parts.ts
+++ b/src/renderer/utils/request-parts.ts
@@ -1,0 +1,60 @@
+export interface QueryParam {
+  key: string;
+  value: string;
+}
+
+export interface FormField {
+  key: string;
+  value: string;
+}
+
+export function parseQueryParams(url: string): QueryParam[] {
+  try {
+    const parsed = new URL(url);
+    return Array.from(parsed.searchParams.entries()).map(([key, value]) => ({ key, value }));
+  } catch {
+    const queryIndex = url.indexOf('?');
+    if (queryIndex === -1) {
+      return [];
+    }
+    const search = url.slice(queryIndex + 1);
+    return search
+      .split('&')
+      .filter(Boolean)
+      .map((pair) => {
+        const [rawKey, ...rest] = pair.split('=');
+        return {
+          key: decodeURIComponent(rawKey || ''),
+          value: decodeURIComponent(rest.join('=') || ''),
+        };
+      });
+  }
+}
+
+export function parseUrlEncodedForm(body: string): FormField[] {
+  if (!body.trim()) {
+    return [];
+  }
+
+  return body
+    .split('&')
+    .filter(Boolean)
+    .map((pair) => {
+      const [rawKey, ...rest] = pair.split('=');
+      try {
+        return {
+          key: decodeURIComponent((rawKey || '').replace(/\+/g, ' ')),
+          value: decodeURIComponent((rest.join('=') || '').replace(/\+/g, ' ')),
+        };
+      } catch {
+        return {
+          key: rawKey || '',
+          value: rest.join('=') || '',
+        };
+      }
+    });
+}
+
+export function isUrlEncodedForm(contentType: string): boolean {
+  return contentType.toLowerCase().includes('application/x-www-form-urlencoded');
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -278,6 +278,8 @@ export interface BreakpointPauseMessage {
 }
 
 export interface BreakpointRequestEdits {
+  method?: string;
+  url?: string;
   headers: HttpHeaders;
   body?: StoredBody;
 }


### PR DESCRIPTION
## Summary
Raises ProxyBoy's non-AI debugging experience toward Proxyman-class workflows on Windows.

## Changes
- Fix duplicate Sidebar/App navigation entries
- Breakpoint method + URL editing (engine + dialog + tests)
- Host tree filter panel
- Structured query params and form-urlencoded body tables
- Header filters, find-in-body, and body copy
- Multi-select bulk delete / export HAR / copy URLs
- Copy as Fetch and PowerShell
- Context menu actions to create breakpoint / map-remote rules
- Better empty-state onboarding (proxy address + cert tip)
- README accuracy updates for breakpoint editing and remaining limitations

## Test plan
- [x] `npx vitest run` (113 tests)
- [x] `npx tsc --noEmit`
- [ ] Manual smoke: host tree filter, breakpoint method/URL edit, multi-select bulk actions, copy formats